### PR TITLE
Enhance reading controls and add command palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/express": "^5.0.3",
         "@types/http-errors": "^2.0.5",
         "@types/morgan": "^1.9.10",
+        "@types/node": "^18.19.127",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.2"
@@ -212,13 +213,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "version": "18.19.127",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
+      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/qs": {
@@ -2207,9 +2208,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/express": "^5.0.3",
     "@types/http-errors": "^2.0.5",
     "@types/morgan": "^1.9.10",
+    "@types/node": "^18.19.127",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.2"

--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,12 @@
     <script type="module" src="/js/main.js"></script>
   </head>
   <body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300">
+    <a
+      href="#beranda"
+      class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-4 focus:left-4 focus:rounded-lg focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white"
+    >
+      Langsung ke konten utama
+    </a>
     <div
       id="statusBanner"
       class="hidden"
@@ -76,6 +82,7 @@
           <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#beranda">Beranda</a>
           <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#kategori">Kategori</a>
           <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#trending">Trending</a>
+          <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#keamanan">Keamanan</a>
           <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#tentang">Tentang</a>
         </div>
         <div class="flex items-center space-x-4">
@@ -127,6 +134,9 @@
         </a>
         <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#trending">
           Trending
+        </a>
+        <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#keamanan">
+          Keamanan
         </a>
         <a class="block px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#tentang">
           Tentang
@@ -300,6 +310,26 @@
                   Temukan berita
                 </button>
               </form>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-white/90">
+                <div class="flex items-start gap-3 rounded-xl border border-white/20 bg-white/10 px-4 py-3">
+                  <span class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/30 text-white">
+                    <i class="fas fa-lock"></i>
+                  </span>
+                  <div class="space-y-1">
+                    <p class="font-semibold">Preferensi terenkripsi</p>
+                    <p class="text-xs text-blue-100">Fingerprint SHA-256 diperbarui otomatis setiap kali Anda menyesuaikan tampilan.</p>
+                  </div>
+                </div>
+                <div class="flex items-start gap-3 rounded-xl border border-white/20 bg-white/10 px-4 py-3">
+                  <span class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/30 text-white">
+                    <i class="fas fa-user-shield"></i>
+                  </span>
+                  <div class="space-y-1">
+                    <p class="font-semibold">Audit satu klik</p>
+                    <p class="text-xs text-blue-100">Panel keamanan mempermudah pengecekan integritas cache offline.</p>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -349,6 +379,79 @@
             <li class="flex gap-2"><i class="fas fa-sync-alt mt-1"></i> Perbarui filter dengan nama yang sama untuk menyimpan ulang preferensi Anda.</li>
             <li class="flex gap-2"><i class="fas fa-keyboard mt-1"></i> Tekan <span class="font-semibold">Ctrl/⌘ + K</span> untuk membuka pusat kendali.</li>
           </ul>
+        </aside>
+      </section>
+
+      <section
+        id="keamanan"
+        aria-labelledby="securityHeading"
+        class="grid grid-cols-1 lg:grid-cols-3 gap-6"
+      >
+        <div class="lg:col-span-2 rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/70 p-6 space-y-6 shadow-sm">
+          <div class="space-y-2">
+            <span class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+              <i class="fas fa-shield-alt"></i>
+              Perlindungan data
+            </span>
+            <h2 id="securityHeading" class="text-2xl font-semibold">Keamanan &amp; privasi NewsApp</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              Preferensi tampilan, filter tersimpan, serta cache berita kini disandikan dengan enkripsi modern dan fingerprint hash sehingga hanya tersimpan di perangkat Anda.
+            </p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="space-y-3">
+              <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Status enkripsi</p>
+              <span
+                id="securityStatusBadge"
+                class="inline-flex items-center gap-2 rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200 px-3 py-1 text-xs font-semibold"
+              >
+                Aktif
+              </span>
+              <p id="securitySupportMessage" class="text-sm text-gray-600 dark:text-gray-300">
+                Penyimpanan terenkripsi aktif dengan AES-256 dan fingerprint SHA-256.
+              </p>
+            </div>
+            <div class="space-y-3">
+              <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Fingerprint preferensi</p>
+              <p
+                id="securityFingerprint"
+                class="rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-3 py-2 font-mono text-sm text-gray-800 dark:text-gray-100"
+              >
+                Belum tersedia
+              </p>
+              <p class="text-xs text-gray-500 dark:text-gray-400">Diperbarui <span id="securityUpdatedAt">-</span></p>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  id="copyFingerprintButton"
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-xs font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+                >
+                  <i class="fas fa-copy"></i>
+                  Salin fingerprint
+                </button>
+                <button
+                  id="integrityCheckButton"
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-xs font-semibold px-3 py-2 transition"
+                >
+                  <i class="fas fa-user-shield"></i>
+                  Audit integritas
+                </button>
+              </div>
+            </div>
+          </div>
+          <p id="integrityStatus" class="text-sm text-blue-600 dark:text-blue-300" aria-live="polite">
+            Menunggu data berita untuk dianalisis.
+          </p>
+        </div>
+        <aside class="rounded-3xl border border-gray-200 dark:border-gray-800 bg-gradient-to-br from-white via-blue-50 to-blue-100 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 p-6 space-y-4 shadow-sm">
+          <div class="space-y-1">
+            <h3 class="text-lg font-semibold text-blue-700 dark:text-blue-300">Lapisan perlindungan</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              Fitur keamanan yang aktif bekerja di latar memastikan data Anda tetap rahasia.
+            </p>
+          </div>
+          <div id="securityHighlights" class="grid grid-cols-1 gap-3"></div>
         </aside>
       </section>
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <title>Berita Terkini - NewsApp</title>
     <meta
       name="description"
-      content="NewsApp menyajikan berita terbaru dari berbagai kategori menggunakan API GNews."
+      content="NewsApp menyajikan berita terbaru, sorotan harian, dan topik populer dari berbagai kategori menggunakan API GNews."
     />
     <link rel="icon" href="https://storage.googleapis.com/a1aa/image/fce953d0-ad31-4a47-7bcd-7590407c1d24.jpg" />
     <script src="https://cdn.tailwindcss.com" defer></script>
@@ -17,19 +17,9 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <link
-      rel="preconnect"
-      href="https://fonts.googleapis.com"
-    />
-    <link
-      rel="preconnect"
-      href="https://fonts.gstatic.com"
-      crossorigin
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <style>
       html {
         scroll-behavior: smooth;
@@ -49,11 +39,24 @@
         border-radius: 10px;
         border: 2px solid #1f2937;
       }
+      .glass {
+        background: rgba(255, 255, 255, 0.55);
+        backdrop-filter: blur(16px);
+      }
+      .dark .glass {
+        background: rgba(17, 24, 39, 0.65);
+      }
     </style>
-    <script src="/js/main.js" defer></script>
+    <script type="module" src="/js/main.js"></script>
   </head>
   <body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300">
-    <header class="sticky top-0 z-50 bg-white dark:bg-gray-800 shadow-md">
+    <div
+      id="statusBanner"
+      class="hidden"
+      role="status"
+      aria-live="polite"
+    ></div>
+    <header class="sticky top-0 z-50 bg-white/95 dark:bg-gray-900/95 backdrop-blur border-b border-gray-200 dark:border-gray-800">
       <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
         <div class="flex items-center space-x-3">
           <img
@@ -64,14 +67,33 @@
             width="40"
             height="40"
           />
-          <a class="text-xl font-semibold tracking-wide select-none" href="#">NewsApp</a>
+          <div>
+            <a class="text-xl font-semibold tracking-wide select-none" href="#">NewsApp</a>
+            <p class="text-xs text-gray-500 dark:text-gray-400 hidden sm:block">Sorotan berita aktual sepanjang hari</p>
+          </div>
         </div>
-        <div class="hidden md:flex space-x-8 font-medium">
-          <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#">Home</a>
+        <div class="hidden md:flex items-center space-x-8 font-medium">
+          <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#beranda">Beranda</a>
           <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#kategori">Kategori</a>
+          <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#trending">Trending</a>
           <a class="hover:text-blue-600 dark:hover:text-blue-400 transition" href="#tentang">Tentang</a>
         </div>
         <div class="flex items-center space-x-4">
+          <button
+            id="commandPaletteButton"
+            type="button"
+            class="hidden md:inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 bg-white/70 dark:bg-gray-800/70 px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 shadow-sm hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            title="Pusat kendali (⌘/Ctrl + K)"
+          >
+            <i class="fas fa-magic"></i>
+            <span>Pusat kendali</span>
+            <span class="hidden xl:inline-flex items-center gap-1 text-[11px] font-semibold text-gray-400 dark:text-gray-500">
+              <span class="rounded border border-gray-300 px-1.5 py-0.5">⌘</span>
+              <span class="rounded border border-gray-300 px-1.5 py-0.5">K</span>
+            </span>
+          </button>
           <button
             id="darkModeToggle"
             class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition text-lg focus:outline-none"
@@ -80,6 +102,13 @@
           >
             <i class="fas fa-moon"></i>
           </button>
+          <a
+            href="#newsletter"
+            class="hidden sm:inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white font-semibold rounded-md px-4 py-2 transition"
+          >
+            <i class="fas fa-bolt"></i>
+            Langganan
+          </a>
           <button
             id="mobileMenuButton"
             class="md:hidden text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition text-2xl focus:outline-none"
@@ -89,62 +118,358 @@
           </button>
         </div>
       </nav>
-      <div
-        id="mobileMenu"
-        class="md:hidden bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 hidden"
-      >
-        <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition" href="#">
-          Home
+      <div id="mobileMenu" class="md:hidden bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 hidden">
+        <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#beranda">
+          Beranda
         </a>
-        <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition" href="#kategori">
+        <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#kategori">
           Kategori
         </a>
-        <a class="block px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 transition" href="#tentang">
+        <a class="block px-4 py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#trending">
+          Trending
+        </a>
+        <a class="block px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-800 transition" href="#tentang">
           Tentang
         </a>
+        <button
+          type="button"
+          data-open-command-palette
+          class="w-full flex items-center justify-between px-4 py-3 border-t border-gray-200 dark:border-gray-800 text-left text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+        >
+          Pusat kendali
+          <span class="text-xs uppercase tracking-wide text-gray-400">Ctrl/⌘ + K</span>
+        </button>
+      </div>
+      <div class="h-1 bg-gray-200 dark:bg-gray-800">
+        <div id="scrollProgress" class="h-1 w-0 bg-blue-600 dark:bg-blue-400 transition-all duration-200"></div>
       </div>
     </header>
 
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <section aria-label="Pencarian berita" class="mb-8">
-        <form id="searchForm" class="flex flex-col sm:flex-row gap-3 sm:gap-4 items-center">
-          <input
-            id="searchInput"
-            name="search"
-            type="text"
-            aria-label="Cari berita"
-            placeholder="Cari berita..."
-            class="flex-grow rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
-          />
-          <select
-            id="categorySelect"
-            aria-label="Pilih kategori berita"
-            class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
-          >
-            <option value="">Semua Kategori</option>
-            <option value="business">Bisnis</option>
-            <option value="technology">Teknologi</option>
-            <option value="sports">Olahraga</option>
-            <option value="health">Kesehatan</option>
-          </select>
-          <button
-            type="submit"
-            class="bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white font-semibold rounded-md px-5 py-2 transition focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            Cari
-          </button>
-        </form>
+    <main id="beranda" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-16">
+      <section
+        aria-label="Sorotan utama NewsApp"
+        class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-600 text-white shadow-xl"
+      >
+        <div class="absolute inset-0 opacity-20 bg-[url('https://www.transparenttextures.com/patterns/dark-dotted.png')]"></div>
+        <div class="relative px-6 sm:px-10 py-12 flex flex-col lg:flex-row lg:items-center gap-12">
+          <div class="lg:w-1/2 space-y-6">
+            <span class="inline-flex items-center gap-2 bg-white/10 text-white px-3 py-1 rounded-full text-sm font-medium">
+              <i class="fas fa-satellite-dish"></i>
+              Update real-time
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight">
+              Jelajahi berita pilihan, analisis mendalam, dan tren global setiap saat
+            </h1>
+            <p class="text-lg text-blue-100">
+              NewsApp mengkurasi berita dari GNews untuk menghadirkan sorotan utama, filter canggih, serta pengalaman membaca yang ramah perangkat.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-3">
+              <a
+                href="#newsSection"
+                class="inline-flex items-center justify-center gap-2 bg-white text-blue-700 font-semibold px-5 py-3 rounded-lg shadow-md hover:shadow-lg transition"
+              >
+                Lihat berita terbaru
+                <i class="fas fa-arrow-right"></i>
+              </a>
+              <a
+                href="#tentang"
+                class="inline-flex items-center justify-center gap-2 border border-white/70 text-white font-semibold px-5 py-3 rounded-lg hover:bg-white/10 transition"
+              >
+                Pelajari cara kerja
+                <i class="fas fa-book-open"></i>
+              </a>
+            </div>
+          </div>
+          <div class="lg:w-1/2 space-y-6">
+            <div class="glass rounded-2xl p-6 shadow-lg space-y-5">
+              <div class="flex items-center justify-between">
+                <h2 class="text-xl font-semibold">Filter pintar</h2>
+                <span class="text-sm text-blue-100">Cari, sortir, dan pilih rentang waktu</span>
+              </div>
+              <form id="searchForm" class="space-y-4">
+                <div class="flex flex-col gap-3">
+                  <label class="text-sm font-semibold text-blue-100" for="searchInput">Kata kunci</label>
+                  <input
+                    id="searchInput"
+                    name="search"
+                    type="text"
+                    aria-label="Cari berita"
+                    placeholder="Cari berita politik, teknologi, ekonomi..."
+                    class="w-full rounded-lg border border-white/30 bg-white/10 text-white placeholder-blue-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white/70 transition"
+                  />
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-semibold text-blue-100" for="categorySelect">Kategori</label>
+                    <select
+                      id="categorySelect"
+                      aria-label="Pilih kategori berita"
+                      class="w-full rounded-lg border border-white/30 bg-white/10 text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white/70 transition"
+                    >
+                      <option value="">Semua Kategori</option>
+                      <option value="business">Bisnis</option>
+                      <option value="technology">Teknologi</option>
+                      <option value="sports">Olahraga</option>
+                      <option value="health">Kesehatan</option>
+                      <option value="entertainment">Hiburan</option>
+                      <option value="science">Sains</option>
+                    </select>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-semibold text-blue-100" for="sortBySelect">Urutkan berdasarkan</label>
+                    <select
+                      id="sortBySelect"
+                      aria-label="Urutkan berita"
+                      class="w-full rounded-lg border border-white/30 bg-white/10 text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white/70 transition"
+                    >
+                      <option value="publishedAt">Terbaru</option>
+                      <option value="relevance">Relevansi</option>
+                      <option value="popularity">Populer</option>
+                    </select>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-semibold text-blue-100" for="timeRangeSelect">Rentang waktu</label>
+                    <select
+                      id="timeRangeSelect"
+                      aria-label="Filter rentang waktu berita"
+                      class="w-full rounded-lg border border-white/30 bg-white/10 text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white/70 transition"
+                    >
+                      <option value="all">Semua waktu</option>
+                      <option value="24h">24 jam terakhir</option>
+                      <option value="48h">48 jam terakhir</option>
+                      <option value="7d">7 hari terakhir</option>
+                      <option value="30d">30 hari terakhir</option>
+                    </select>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-semibold text-blue-100" for="pageSizeSelect">Jumlah per halaman</label>
+                    <select
+                      id="pageSizeSelect"
+                      aria-label="Jumlah artikel per halaman"
+                      class="w-full rounded-lg border border-white/30 bg-white/10 text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white/70 transition"
+                    >
+                      <option value="9">9 / halaman</option>
+                      <option value="12">12 / halaman</option>
+                      <option value="18">18 / halaman</option>
+                      <option value="24">24 / halaman</option>
+                    </select>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <span class="text-sm font-semibold text-blue-100">Topik cepat</span>
+                    <div class="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        class="quick-filter inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/70"
+                        data-query="pemilu"
+                      >
+                        <i class="fas fa-vote-yea"></i>
+                        Pemilu
+                      </button>
+                      <button
+                        type="button"
+                        class="quick-filter inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/70"
+                        data-query="iklim"
+                      >
+                        <i class="fas fa-globe-asia"></i>
+                        Iklim
+                      </button>
+                      <button
+                        type="button"
+                        class="quick-filter inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/70"
+                        data-query="startup"
+                      >
+                        <i class="fas fa-rocket"></i>
+                        Startup
+                      </button>
+                      <button
+                        type="button"
+                        class="quick-filter inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/70"
+                        data-query="ekonomi global"
+                      >
+                        <i class="fas fa-chart-line"></i>
+                        Ekonomi global
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  type="submit"
+                  class="w-full inline-flex items-center justify-center gap-2 bg-white text-blue-700 font-semibold rounded-lg px-6 py-3 transition hover:shadow-lg"
+                >
+                  <i class="fas fa-search"></i>
+                  Temukan berita
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
       </section>
 
-      <section id="newsSection" aria-label="Daftar berita terkini" class="min-h-[300px]">
-        <div id="loadingIndicator" class="flex justify-center items-center py-20" hidden aria-live="polite" aria-busy="true">
-          <svg
-            class="animate-spin h-10 w-10 text-blue-600 dark:text-blue-400"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
+      <section aria-label="Filter tersimpan" class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="lg:col-span-2 rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/60 p-6 space-y-5 shadow-sm">
+          <div class="flex flex-col gap-1">
+            <h2 class="text-xl font-semibold">Kelola filter favorit</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400">Simpan kombinasi pencarian khusus untuk akses cepat.</p>
+          </div>
+          <div class="flex flex-col gap-3 sm:flex-row">
+            <label class="sr-only" for="savedFilterName">Nama filter</label>
+            <input
+              id="savedFilterName"
+              type="text"
+              class="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Contoh: Pagi teknologi"
+              autocomplete="off"
+            />
+            <div class="flex flex-wrap gap-3">
+              <button
+                id="saveCurrentFilter"
+                type="button"
+                class="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2.5 transition"
+              >
+                <i class="fas fa-bookmark"></i>
+                Simpan filter
+              </button>
+              <button
+                id="clearSavedFilters"
+                type="button"
+                class="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+              >
+                <i class="fas fa-eraser"></i>
+                Bersihkan
+              </button>
+            </div>
+          </div>
+          <ul id="savedFiltersList" class="space-y-3"></ul>
+        </div>
+        <aside class="rounded-3xl border border-dashed border-blue-200 dark:border-blue-900 bg-blue-50/70 dark:bg-blue-900/20 p-6 space-y-3">
+          <h3 class="text-lg font-semibold text-blue-700 dark:text-blue-300">Tips personalisasi</h3>
+          <ul class="space-y-2 text-sm text-blue-900/80 dark:text-blue-100">
+            <li class="flex gap-2"><i class="fas fa-mouse-pointer mt-1"></i> Terapkan filter kategori atau rentang waktu sebelum menyimpan.</li>
+            <li class="flex gap-2"><i class="fas fa-layer-group mt-1"></i> Gunakan beberapa filter tersimpan untuk switching niche secara instan.</li>
+            <li class="flex gap-2"><i class="fas fa-sync-alt mt-1"></i> Perbarui filter dengan nama yang sama untuk menyimpan ulang preferensi Anda.</li>
+            <li class="flex gap-2"><i class="fas fa-keyboard mt-1"></i> Tekan <span class="font-semibold">Ctrl/⌘ + K</span> untuk membuka pusat kendali.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section
+        id="statsSection"
+        aria-live="polite"
+        class="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm text-gray-700 dark:text-gray-300"
+      >
+        <div class="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/70 p-6 shadow-sm">
+          <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Total artikel</p>
+          <p id="totalArticlesStat" class="mt-2 text-2xl font-semibold">-</p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Hasil berdasarkan filter aktif</p>
+        </div>
+        <div class="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/70 p-6 shadow-sm">
+          <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Filter aktif</p>
+          <p id="activeFiltersStat" class="mt-2 text-base font-medium leading-relaxed">
+            -
+          </p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Gabungan kata kunci, kategori, dan urutan</p>
+        </div>
+        <div class="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/70 p-6 shadow-sm">
+          <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Terakhir diperbarui</p>
+          <p id="lastUpdatedStat" class="mt-2 text-lg font-semibold">-</p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Data ditarik langsung dari API GNews</p>
+        </div>
+      </section>
+
+      <section id="featured" class="space-y-6" aria-label="Artikel unggulan">
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-semibold">Sorotan unggulan</h2>
+          <span class="text-sm text-gray-500 dark:text-gray-400">Artikel pertama dari hasil pencarian</span>
+        </div>
+        <article
+          id="featuredArticle"
+          class="hidden overflow-hidden rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800 shadow-lg transition"
+        ></article>
+      </section>
+
+      <section id="trending" aria-label="Topik populer" class="space-y-6">
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-semibold">Topik populer hari ini</h2>
+          <button
+            id="refreshTrending"
+            type="button"
+            class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:underline"
           >
+            <i class="fas fa-sync-alt"></i>
+            Segarkan ide
+          </button>
+        </div>
+        <div id="trendingTopics" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4"></div>
+      </section>
+
+      <section id="niche" aria-label="Fokus niche" class="space-y-6">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold">Sorotan niche dan industri</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400">Pantau peluang di sektor khusus sesuai kebutuhan bisnis Anda.</p>
+          </div>
+          <p class="text-xs uppercase tracking-[0.2em] text-blue-500 dark:text-blue-300">Dipilih kurator NewsApp</p>
+        </div>
+        <div id="nicheTopics" class="grid grid-cols-1 md:grid-cols-3 gap-4"></div>
+      </section>
+
+      <section id="newsSection" aria-label="Daftar berita terkini" class="space-y-6">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div class="space-y-2">
+            <div class="flex flex-wrap items-center gap-3">
+              <h2 class="text-2xl font-semibold">Semua berita</h2>
+              <span
+                id="offlineBadge"
+                class="hidden inline-flex items-center gap-2 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/80 dark:text-amber-100 px-3 py-1 text-xs font-semibold"
+              >
+                <i class="fas fa-wifi"></i>
+                Mode offline: menampilkan cache
+              </span>
+            </div>
+            <p id="resultSummary" class="text-sm text-gray-600 dark:text-gray-400"></p>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 justify-start lg:justify-end">
+            <div id="viewToggle" class="inline-flex items-center gap-2 rounded-full bg-gray-100 dark:bg-gray-800 p-1" role="group" aria-label="Pilih tampilan berita">
+              <button
+                type="button"
+                data-view="grid"
+                class="px-4 py-2 rounded-full text-sm font-semibold text-gray-700 dark:text-gray-200 transition"
+              >
+                <i class="fas fa-th-large mr-2"></i>
+                Grid
+              </button>
+              <button
+                type="button"
+                data-view="list"
+                class="px-4 py-2 rounded-full text-sm font-semibold text-gray-500 dark:text-gray-300 transition"
+              >
+                <i class="fas fa-list mr-2"></i>
+                Daftar
+              </button>
+            </div>
+            <button
+              id="densityToggle"
+              type="button"
+              data-density="comfortable"
+              aria-pressed="false"
+              class="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 transition hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            >
+              <i class="fas fa-layer-group"></i>
+              <span class="density-label">Ruang lega</span>
+            </button>
+            <button
+              id="refreshArticles"
+              type="button"
+              class="inline-flex items-center gap-2 rounded-full bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white text-sm font-semibold px-4 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+              aria-label="Segarkan berita"
+            >
+              <i class="fas fa-sync-alt"></i>
+              <span>Segarkan</span>
+            </button>
+          </div>
+        </div>
+        <div id="loadingIndicator" class="flex justify-center items-center py-16" hidden aria-live="polite" aria-busy="true">
+          <svg class="animate-spin h-10 w-10 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
           </svg>
@@ -154,34 +479,207 @@
         <div id="noResultsMessage" role="alert" class="text-center text-gray-600 dark:text-gray-400 font-semibold py-10 hidden">
           Berita tidak ditemukan.
         </div>
-        <div id="newsGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8"></div>
+        <div id="newsGrid" class="grid grid-cols-1 gap-6"></div>
       </section>
 
-      <nav id="pagination" aria-label="Navigasi halaman berita" class="flex justify-center items-center space-x-3 mt-12">
+      <nav id="pagination" aria-label="Navigasi halaman berita" class="flex flex-wrap justify-center items-center gap-4 pt-6">
         <button
           id="prevPage"
-          class="px-4 py-2 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          class="px-5 py-3 rounded-lg bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
           disabled
           aria-disabled="true"
         >
-          <i class="fas fa-chevron-left mr-1"></i>
+          <i class="fas fa-chevron-left mr-2"></i>
           Sebelumnya
         </button>
         <span id="pageInfo" class="font-semibold text-gray-700 dark:text-gray-300 select-none"></span>
         <button
           id="nextPage"
-          class="px-4 py-2 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          class="px-5 py-3 rounded-lg bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
           disabled
           aria-disabled="true"
         >
           Berikutnya
-          <i class="fas fa-chevron-right ml-1"></i>
+          <i class="fas fa-chevron-right ml-2"></i>
         </button>
       </nav>
+
+      <section id="kategori" class="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+        <div class="space-y-4">
+          <h2 class="text-3xl font-semibold">Kategorikan bacaan Anda</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
+            Pilih kategori favorit untuk menemukan berita yang paling relevan. Filter yang Anda terapkan akan mengubah daftar artikel secara instan dan disimpan selama sesi berlangsung.
+          </p>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li><i class="fas fa-check text-green-500 mr-2"></i> Bisnis & ekonomi global</li>
+            <li><i class="fas fa-check text-green-500 mr-2"></i> Teknologi & inovasi</li>
+            <li><i class="fas fa-check text-green-500 mr-2"></i> Olahraga & hiburan</li>
+            <li><i class="fas fa-check text-green-500 mr-2"></i> Kesehatan & sains</li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-dashed border-blue-300 dark:border-blue-500/60 p-8">
+          <h3 class="text-xl font-semibold mb-4">Sorotan kategori cepat</h3>
+          <div class="grid grid-cols-2 gap-4 text-sm">
+            <button
+              type="button"
+              class="category-pill inline-flex items-center justify-center gap-2 rounded-xl border border-blue-300/70 bg-white/70 px-4 py-3 font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-900/40 dark:text-blue-200"
+              data-category="business"
+            >
+              <i class="fas fa-briefcase"></i>
+              Bisnis
+            </button>
+            <button
+              type="button"
+              class="category-pill inline-flex items-center justify-center gap-2 rounded-xl border border-blue-300/70 bg-white/70 px-4 py-3 font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-900/40 dark:text-blue-200"
+              data-category="technology"
+            >
+              <i class="fas fa-microchip"></i>
+              Teknologi
+            </button>
+            <button
+              type="button"
+              class="category-pill inline-flex items-center justify-center gap-2 rounded-xl border border-blue-300/70 bg-white/70 px-4 py-3 font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-900/40 dark:text-blue-200"
+              data-category="sports"
+            >
+              <i class="fas fa-basketball-ball"></i>
+              Olahraga
+            </button>
+            <button
+              type="button"
+              class="category-pill inline-flex items-center justify-center gap-2 rounded-xl border border-blue-300/70 bg-white/70 px-4 py-3 font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-900/40 dark:text-blue-200"
+              data-category="health"
+            >
+              <i class="fas fa-heartbeat"></i>
+              Kesehatan
+            </button>
+            <button
+              type="button"
+              class="category-pill inline-flex items-center justify-center gap-2 rounded-xl border border-blue-300/70 bg-white/70 px-4 py-3 font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-900/40 dark:text-blue-200"
+              data-category="science"
+            >
+              <i class="fas fa-flask"></i>
+              Sains
+            </button>
+            <button
+              type="button"
+              class="category-pill inline-flex items-center justify-center gap-2 rounded-xl border border-blue-300/70 bg-white/70 px-4 py-3 font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-900/40 dark:text-blue-200"
+              data-category="entertainment"
+            >
+              <i class="fas fa-film"></i>
+              Hiburan
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section id="newsletter" class="relative overflow-hidden rounded-3xl bg-gray-100 dark:bg-gray-800 p-10">
+        <div class="absolute inset-0 opacity-20 bg-[url('https://www.transparenttextures.com/patterns/asfalt-light.png')] dark:opacity-10"></div>
+        <div class="relative flex flex-col lg:flex-row items-center gap-10">
+          <div class="lg:w-1/2 space-y-4">
+            <h2 class="text-3xl font-semibold">Dapatkan sorotan pagi setiap hari</h2>
+            <p class="text-gray-600 dark:text-gray-400">
+              Masukkan alamat email Anda untuk menerima kurasi berita penting langsung ke kotak masuk setiap pagi. Kami tidak akan mengirimkan spam dan Anda dapat berhenti berlangganan kapan pun.
+            </p>
+          </div>
+          <form class="lg:w-1/2 w-full flex flex-col sm:flex-row gap-3">
+            <label class="sr-only" for="newsletterEmail">Email</label>
+            <input
+              id="newsletterEmail"
+              type="email"
+              placeholder="nama@perusahaan.com"
+              class="flex-grow rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white font-semibold rounded-lg px-6 py-3 transition"
+            >
+              <i class="fas fa-paper-plane"></i>
+              Daftar
+            </button>
+          </form>
+        </div>
+      </section>
     </main>
 
-    <footer id="tentang" class="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-center py-6 mt-16 select-none">
-      <p>© 2025 NewsApp. Semua hak cipta dilindungi.</p>
+    <button
+      id="backToTop"
+      type="button"
+      class="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white font-semibold px-4 py-3 shadow-lg transition opacity-0 pointer-events-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+      aria-label="Kembali ke atas"
+    >
+      <i class="fas fa-arrow-up"></i>
+      <span class="hidden sm:inline text-sm">Ke atas</span>
+    </button>
+
+    <footer id="tentang" class="bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 mt-16">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="space-y-3">
+          <h3 class="text-lg font-semibold">Tentang NewsApp</h3>
+          <p class="text-sm leading-relaxed">
+            NewsApp adalah portal berita adaptif yang memanfaatkan API GNews untuk menghadirkan berita terbaru secara aman melalui server kami. Cache pintar memastikan performa cepat tanpa mengorbankan akurasi.
+          </p>
+        </div>
+        <div class="space-y-3">
+          <h3 class="text-lg font-semibold">Fitur unggulan</h3>
+          <ul class="text-sm space-y-2">
+            <li><i class="fas fa-shield-alt text-blue-500 mr-2"></i> API key tersembunyi di server</li>
+            <li><i class="fas fa-sync text-blue-500 mr-2"></i> Data segar dengan caching pintar</li>
+            <li><i class="fas fa-moon text-blue-500 mr-2"></i> Mode gelap adaptif</li>
+            <li><i class="fas fa-mobile-alt text-blue-500 mr-2"></i> Desain responsif</li>
+          </ul>
+        </div>
+        <div class="space-y-3">
+          <h3 class="text-lg font-semibold">Hubungi kami</h3>
+          <p class="text-sm">Ada masukan atau ide fitur? Kirimkan ke <a class="text-blue-600 dark:text-blue-400 hover:underline" href="mailto:hi@newsapp.dev">hi@newsapp.dev</a></p>
+        </div>
+      </div>
+      <div class="bg-gray-200 dark:bg-gray-950 text-center text-sm py-4 select-none">
+        © 2025 NewsApp. Dibuat dengan ❤ untuk pembaca berita Indonesia.
+      </div>
     </footer>
+
+    <div
+      id="commandPalette"
+      class="hidden fixed inset-0 z-50 bg-transparent"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+    >
+      <div id="commandPaletteOverlay" class="absolute inset-0 bg-gray-900/50 backdrop-blur-sm"></div>
+      <div class="relative mx-auto mt-24 max-w-2xl px-4 sm:px-6">
+        <div class="overflow-hidden rounded-3xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-2xl">
+          <div class="flex items-center gap-3 border-b border-gray-200 dark:border-gray-800 px-4 py-3">
+            <span class="text-gray-400 dark:text-gray-500 text-lg"><i class="fas fa-search"></i></span>
+            <input
+              id="commandPaletteSearch"
+              type="search"
+              class="flex-1 bg-transparent text-sm focus:outline-none placeholder-gray-400 dark:placeholder-gray-500"
+              placeholder="Cari atau jalankan perintah (mis. tema gelap, fokus pencarian)"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="hidden sm:flex items-center gap-1 text-[11px] font-semibold text-gray-400 dark:text-gray-500">
+              <span class="rounded border border-gray-300 px-1.5 py-0.5">esc</span>
+            </div>
+            <button
+              id="commandPaletteClose"
+              type="button"
+              class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition"
+            >
+              <span class="sr-only">Tutup pusat kendali</span>
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
+          <ul id="commandPaletteList" class="max-h-80 overflow-y-auto py-2" role="listbox" aria-label="Daftar perintah"></ul>
+          <div class="flex items-center justify-between border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800 px-4 py-2 text-xs text-gray-500 dark:text-gray-400">
+            <span>Gunakan ↑ ↓ untuk navigasi, Enter untuk memilih.</span>
+            <span class="hidden sm:inline-flex items-center gap-1">
+              <span class="rounded border border-gray-300 px-1.5 py-0.5">⌘</span>
+              <span class="rounded border border-gray-300 px-1.5 py-0.5">K</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -107,6 +107,13 @@ export const COMMAND_ACTIONS = [
     keywords: 'refresh segarkan update',
     shortcut: 'R',
   },
+  {
+    id: 'run-integrity-check',
+    title: 'Audit keamanan data',
+    description: 'Hitung ulang fingerprint konten dan preferensi.',
+    icon: 'fas fa-shield-alt',
+    keywords: 'keamanan integritas hash fingerprint',
+  },
 ];
 
 export const TRENDING_IDEAS = [
@@ -202,5 +209,28 @@ export const NICHE_FOCUS_AREAS = [
     icon: 'fas fa-chalkboard-teacher',
     description: 'Solusi edtech, platform belajar mandiri, dan kebijakan pendidikan.',
     query: 'teknologi pendidikan indonesia',
+  },
+];
+
+export const SECURITY_MEASURES = [
+  {
+    title: 'Enkripsi AES-256',
+    description: 'Preferensi dan cache berita tersimpan dengan AES-GCM berbasis Web Crypto.',
+    icon: 'fas fa-lock',
+  },
+  {
+    title: 'Fingerprint SHA-256',
+    description: 'Setiap perubahan preferensi menghasilkan hash baru untuk verifikasi integritas.',
+    icon: 'fas fa-fingerprint',
+  },
+  {
+    title: 'Deteksi Mode Offline',
+    description: 'Cache terenkripsi digunakan otomatis saat koneksi terputus.',
+    icon: 'fas fa-wifi-slash',
+  },
+  {
+    title: 'Audit sekali sentuh',
+    description: 'Jalankan pemeriksaan integritas langsung dari panel keamanan.',
+    icon: 'fas fa-user-shield',
   },
 ];

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -1,0 +1,206 @@
+export const API_BASE_URL = '/api/news';
+
+export const DEFAULT_PAGE_SIZE = 9;
+
+export const PAGE_SIZE_OPTIONS = [9, 12, 18, 24];
+
+export const SORT_OPTIONS = [
+  { value: 'publishedAt', label: 'Terbaru' },
+  { value: 'relevance', label: 'Relevansi' },
+  { value: 'popularity', label: 'Populer' },
+];
+
+export const TIME_RANGE_OPTIONS = [
+  { value: 'all', label: 'Semua waktu' },
+  { value: '24h', label: '24 jam terakhir' },
+  { value: '48h', label: '48 jam terakhir' },
+  { value: '7d', label: '7 hari terakhir' },
+  { value: '30d', label: '30 hari terakhir' },
+];
+
+export const CATEGORY_OPTIONS = [
+  { value: '', label: 'Semua kategori' },
+  { value: 'business', label: 'Bisnis' },
+  { value: 'technology', label: 'Teknologi' },
+  { value: 'sports', label: 'Olahraga' },
+  { value: 'health', label: 'Kesehatan' },
+  { value: 'entertainment', label: 'Hiburan' },
+  { value: 'science', label: 'Sains' },
+];
+
+export const STORAGE_KEYS = {
+  preferences: 'newsapp.preferences.v3',
+  cachedArticles: 'newsapp.cachedArticles.v1',
+  savedFilters: 'newsapp.savedFilters.v1',
+};
+
+export const READING_DENSITY_OPTIONS = [
+  {
+    value: 'comfortable',
+    label: 'Ruang lega',
+    description: 'Spasi longgar untuk pengalaman membaca santai.',
+  },
+  {
+    value: 'compact',
+    label: 'Mode padat',
+    description: 'Tampilkan lebih banyak artikel dalam satu layar dengan jarak rapat.',
+  },
+];
+
+export const COMMAND_ACTIONS = [
+  {
+    id: 'focus-search',
+    title: 'Fokus ke pencarian',
+    description: 'Sorot kolom pencarian utama untuk mulai mengetik.',
+    icon: 'fas fa-search',
+    keywords: 'search cari fokus',
+    shortcut: '/',
+  },
+  {
+    id: 'toggle-theme',
+    title: 'Aktifkan mode gelap',
+    description: 'Beralih antara tema terang dan gelap.',
+    icon: 'fas fa-adjust',
+    keywords: 'tema theme dark gelap terang',
+    shortcut: 'T',
+  },
+  {
+    id: 'toggle-density',
+    title: 'Ganti kepadatan tampilan',
+    description: 'Sesuaikan jarak antar kartu berita.',
+    icon: 'fas fa-grip-horizontal',
+    keywords: 'density padat compact rapat nyaman',
+  },
+  {
+    id: 'view-grid',
+    title: 'Gunakan tampilan grid',
+    description: 'Susun artikel dalam kisi 3 kolom responsif.',
+    icon: 'fas fa-th-large',
+    keywords: 'grid kartu layout',
+  },
+  {
+    id: 'view-list',
+    title: 'Gunakan tampilan daftar',
+    description: 'Baca artikel secara vertikal seperti daftar.',
+    icon: 'fas fa-list',
+    keywords: 'list daftar baris',
+  },
+  {
+    id: 'open-trending',
+    title: 'Buka bagian trending',
+    description: 'Loncat ke ide topik populer hari ini.',
+    icon: 'fas fa-fire-alt',
+    keywords: 'trending populer ide',
+  },
+  {
+    id: 'open-saved-filters',
+    title: 'Buka filter tersimpan',
+    description: 'Kelola preset pencarian yang pernah disimpan.',
+    icon: 'fas fa-bookmark',
+    keywords: 'filter tersimpan favorit',
+  },
+  {
+    id: 'refresh-articles',
+    title: 'Segarkan daftar berita',
+    description: 'Ambil artikel terbaru dari API.',
+    icon: 'fas fa-sync',
+    keywords: 'refresh segarkan update',
+    shortcut: 'R',
+  },
+];
+
+export const TRENDING_IDEAS = [
+  {
+    title: 'Teknologi AI',
+    query: 'kecerdasan buatan',
+    icon: 'fas fa-robot',
+    description: 'Inovasi terbaru dalam kecerdasan buatan dan otomatisasi.',
+  },
+  {
+    title: 'Ekonomi Hijau',
+    query: 'ekonomi hijau',
+    icon: 'fas fa-leaf',
+    description: 'Transisi energi dan kebijakan ramah lingkungan global.',
+  },
+  {
+    title: 'Pasar Kripto',
+    query: 'mata uang kripto',
+    icon: 'fas fa-coins',
+    description: 'Tren harga terbaru dan regulasi aset digital.',
+  },
+  {
+    title: 'Startup Asia',
+    query: 'startup asia tenggara',
+    icon: 'fas fa-rocket',
+    description: 'Pendanaan dan cerita sukses perusahaan rintisan kawasan.',
+  },
+  {
+    title: 'Kebijakan Publik',
+    query: 'kebijakan publik indonesia',
+    icon: 'fas fa-landmark',
+    description: 'Reformasi dan dinamika politik di pemerintahan.',
+  },
+  {
+    title: 'Inovasi Kesehatan',
+    query: 'teknologi kesehatan',
+    icon: 'fas fa-heartbeat',
+    description: 'Penemuan medis dan layanan kesehatan digital.',
+  },
+  {
+    title: 'Keamanan Siber',
+    query: 'keamanan siber',
+    icon: 'fas fa-shield-alt',
+    description: 'Ancaman dan strategi melindungi data digital.',
+  },
+  {
+    title: 'Mobil Listrik',
+    query: 'kendaraan listrik',
+    icon: 'fas fa-car-side',
+    description: 'Perkembangan industri otomotif berbasis listrik.',
+  },
+  {
+    title: 'Rantai Pasok',
+    query: 'rantai pasok global',
+    icon: 'fas fa-shipping-fast',
+    description: 'Dinamika logistik dan pengaruh geopolitik.',
+  },
+  {
+    title: 'Media Sosial',
+    query: 'tren media sosial',
+    icon: 'fas fa-hashtag',
+    description: 'Platform populer dan budaya digital kekinian.',
+  },
+];
+
+export const NICHE_FOCUS_AREAS = [
+  {
+    title: 'Ekonomi Kreator',
+    icon: 'fas fa-video',
+    description: 'Strategi konten, platform baru, dan peluang monetisasi kreator digital.',
+    query: 'ekonomi kreator indonesia',
+  },
+  {
+    title: 'Pertanian Cerdas',
+    icon: 'fas fa-seedling',
+    description: 'Teknologi agrikultur presisi, hydroponik, dan inovasi pangan lokal.',
+    query: 'pertanian cerdas indonesia',
+  },
+  {
+    title: 'Wisata Berkelanjutan',
+    icon: 'fas fa-route',
+    description: 'Destinasi wisata hijau dan prakarsa pariwisata bertanggung jawab.',
+    query: 'pariwisata berkelanjutan nusantara',
+  },
+  {
+    title: 'UMKM Digital',
+    icon: 'fas fa-store',
+    description: 'Transformasi usaha kecil melalui e-commerce dan platform digital.',
+    query: 'UMKM digital indonesia',
+  },
+  {
+    title: 'Teknologi Pendidikan',
+    icon: 'fas fa-chalkboard-teacher',
+    description: 'Solusi edtech, platform belajar mandiri, dan kebijakan pendidikan.',
+    query: 'teknologi pendidikan indonesia',
+  },
+];

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,279 +1,1015 @@
-(() => {
-  const PAGE_SIZE = 9;
+import {
+  CATEGORY_OPTIONS,
+  COMMAND_ACTIONS,
+  PAGE_SIZE_OPTIONS,
+  SORT_OPTIONS,
+  TIME_RANGE_OPTIONS,
+} from './constants.js';
+import { createNewsClient } from './services.newsClient.js';
+import { createPreferencesStore } from './state.preferences.js';
+import { createSavedFiltersStore } from './state.filters.js';
+import {
+  renderArticles,
+  renderFeaturedArticle,
+  renderNicheFocus,
+  renderSavedFilters,
+  renderSkeletons,
+  renderStats,
+  renderTrendingTopics,
+  updateStatusBanner,
+  updateViewToggle,
+  updateDensityToggle,
+} from './ui.renderers.js';
+import { preferReducedMotion, qsa, qs, setHidden, toggleClass } from './utils.dom.js';
 
-  const newsGrid = document.getElementById('newsGrid');
-  const loadingIndicator = document.getElementById('loadingIndicator');
-  const errorMessage = document.getElementById('errorMessage');
-  const noResultsMessage = document.getElementById('noResultsMessage');
-  const searchForm = document.getElementById('searchForm');
-  const searchInput = document.getElementById('searchInput');
-  const categorySelect = document.getElementById('categorySelect');
-  const prevPageBtn = document.getElementById('prevPage');
-  const nextPageBtn = document.getElementById('nextPage');
-  const pageInfo = document.getElementById('pageInfo');
-  const darkModeToggle = document.getElementById('darkModeToggle');
-  const mobileMenuButton = document.getElementById('mobileMenuButton');
-  const mobileMenu = document.getElementById('mobileMenu');
+const newsClient = createNewsClient();
+const preferencesStore = createPreferencesStore();
+const savedFiltersStore = createSavedFiltersStore();
 
-  let currentPage = 1;
-  let totalResults = 0;
-  let currentQuery = '';
-  let currentCategory = '';
+const elements = {
+  newsGrid: qs('#newsGrid'),
+  loadingIndicator: qs('#loadingIndicator'),
+  errorMessage: qs('#errorMessage'),
+  noResultsMessage: qs('#noResultsMessage'),
+  searchForm: qs('#searchForm'),
+  searchInput: qs('#searchInput'),
+  categorySelect: qs('#categorySelect'),
+  sortBySelect: qs('#sortBySelect'),
+  timeRangeSelect: qs('#timeRangeSelect'),
+  pageSizeSelect: qs('#pageSizeSelect'),
+  prevPage: qs('#prevPage'),
+  nextPage: qs('#nextPage'),
+  pageInfo: qs('#pageInfo'),
+  resultSummary: qs('#resultSummary'),
+  featuredArticle: qs('#featuredArticle'),
+  totalArticlesStat: qs('#totalArticlesStat'),
+  activeFiltersStat: qs('#activeFiltersStat'),
+  lastUpdatedStat: qs('#lastUpdatedStat'),
+  trendingTopics: qs('#trendingTopics'),
+  refreshTrending: qs('#refreshTrending'),
+  darkModeToggle: qs('#darkModeToggle'),
+  mobileMenuButton: qs('#mobileMenuButton'),
+  mobileMenu: qs('#mobileMenu'),
+  quickFilters: qsa('.quick-filter'),
+  categoryPills: qsa('.category-pill'),
+  viewToggle: qs('#viewToggle'),
+  savedFiltersList: qs('#savedFiltersList'),
+  saveCurrentFilter: qs('#saveCurrentFilter'),
+  savedFilterName: qs('#savedFilterName'),
+  clearSavedFilters: qs('#clearSavedFilters'),
+  nicheTopics: qs('#nicheTopics'),
+  statusBanner: qs('#statusBanner'),
+  offlineBadge: qs('#offlineBadge'),
+  densityToggle: qs('#densityToggle'),
+  refreshArticles: qs('#refreshArticles'),
+  commandPalette: qs('#commandPalette'),
+  commandPaletteButton: qs('#commandPaletteButton'),
+  commandPaletteOverlay: qs('#commandPaletteOverlay'),
+  commandPaletteClose: qs('#commandPaletteClose'),
+  commandPaletteSearch: qs('#commandPaletteSearch'),
+  commandPaletteList: qs('#commandPaletteList'),
+  backToTop: qs('#backToTop'),
+  scrollProgress: qs('#scrollProgress'),
+};
 
-  const defaultImage = 'https://placehold.co/600x400/png?text=Gambar+Berita+Tidak+Tersedia';
+const uiState = {
+  page: 1,
+  totalResults: 0,
+  articles: [],
+  lastUpdated: null,
+  latestQuery: '',
+  isLoading: false,
+};
 
-  const formatDate = (dateString) => {
-    if (!dateString) return '';
-    const months = [
-      'Januari',
-      'Februari',
-      'Maret',
-      'April',
-      'Mei',
-      'Juni',
-      'Juli',
-      'Agustus',
-      'September',
-      'Oktober',
-      'November',
-      'Desember',
-    ];
-    const date = new Date(dateString);
-    if (Number.isNaN(date.getTime())) return '';
-    const day = date.getDate();
-    const month = months[date.getMonth()];
-    const year = date.getFullYear();
-    return `${day} ${month} ${year}`;
-  };
+const commandPaletteState = {
+  isOpen: false,
+  items: COMMAND_ACTIONS.slice(),
+  filtered: COMMAND_ACTIONS.slice(),
+  activeIndex: 0,
+  returnFocusTo: null,
+};
 
-  const setHidden = (element, hidden) => {
-    if (!element) return;
-    element.hidden = hidden;
-    if (hidden) {
-      element.classList.add('hidden');
+const applyTheme = (theme = 'system') => {
+  const root = document.documentElement;
+  let resolved = theme;
+  if (theme === 'system') {
+    resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  root.classList.toggle('dark', resolved === 'dark');
+  elements.darkModeToggle?.setAttribute('aria-pressed', resolved === 'dark');
+  const icon = resolved === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+  const label = resolved === 'dark' ? 'Aktifkan mode terang' : 'Aktifkan mode gelap';
+  elements.darkModeToggle?.setAttribute('title', label);
+  elements.darkModeToggle?.setAttribute('aria-label', label);
+  if (elements.darkModeToggle?.firstElementChild) {
+    elements.darkModeToggle.firstElementChild.className = icon;
+  }
+};
+
+const computeCommandItems = () => {
+  const resolvedTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+  const { density, viewMode } = preferencesStore.getState();
+  return COMMAND_ACTIONS.map((action) => {
+    const item = { ...action };
+    switch (action.id) {
+      case 'toggle-theme':
+        item.title = resolvedTheme === 'dark' ? 'Aktifkan mode terang' : 'Aktifkan mode gelap';
+        item.description =
+          resolvedTheme === 'dark'
+            ? 'Beralih ke antarmuka terang untuk suasana yang lebih cerah.'
+            : 'Aktifkan mode gelap agar mata lebih nyaman saat malam hari.';
+        break;
+      case 'toggle-density':
+        item.title = density === 'compact' ? 'Gunakan ruang lega' : 'Gunakan mode padat';
+        item.description =
+          density === 'compact'
+            ? 'Kembalikan jarak antar kartu agar tampilan lebih lega.'
+            : 'Padatkan kartu supaya lebih banyak berita dalam satu layar.';
+        break;
+      case 'view-grid':
+        item.disabled = viewMode === 'grid';
+        if (item.disabled) {
+          item.description = 'Saat ini Anda sudah menggunakan tampilan grid.';
+        }
+        break;
+      case 'view-list':
+        item.disabled = viewMode === 'list';
+        if (item.disabled) {
+          item.description = 'Saat ini Anda sudah menggunakan tampilan daftar.';
+        }
+        break;
+      default:
+        break;
+    }
+    return item;
+  });
+};
+
+const updateCommandPaletteActive = () => {
+  if (!elements.commandPaletteList) return;
+  qsa('[data-command-index]', elements.commandPaletteList).forEach((item) => {
+    const index = Number(item.dataset.commandIndex);
+    const isActive = index === commandPaletteState.activeIndex;
+    toggleClass(item, 'bg-blue-50', isActive);
+    toggleClass(item, 'dark:bg-blue-500/20', isActive);
+    toggleClass(item, 'border-blue-500/60', isActive);
+    item.setAttribute('aria-selected', String(isActive));
+    if (isActive) {
+      item.scrollIntoView({ block: 'nearest' });
+    }
+  });
+};
+
+const renderCommandPaletteItems = () => {
+  if (!elements.commandPaletteList) return;
+  elements.commandPaletteList.innerHTML = '';
+  if (!commandPaletteState.filtered.length) {
+    const empty = document.createElement('li');
+    empty.className = 'px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400';
+    empty.textContent = 'Perintah tidak ditemukan. Coba kata kunci lain.';
+    empty.setAttribute('aria-disabled', 'true');
+    elements.commandPaletteList.appendChild(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  commandPaletteState.filtered.forEach((action, index) => {
+    const item = document.createElement('li');
+    item.className = `flex items-center justify-between gap-4 rounded-xl border border-transparent px-4 py-3 transition ${
+      action.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-blue-50 dark:hover:bg-slate-800'
+    }`;
+    item.dataset.commandIndex = String(index);
+    item.dataset.commandId = action.id;
+    item.setAttribute('role', 'option');
+    item.setAttribute('aria-selected', 'false');
+    if (action.disabled) {
+      item.setAttribute('aria-disabled', 'true');
+    }
+    item.innerHTML = `
+      <div class="flex items-center gap-3">
+        <span class="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600/10 text-blue-600 dark:bg-blue-500/20 dark:text-blue-200">
+          <i class="${action.icon}"></i>
+        </span>
+        <div class="flex flex-col">
+          <span class="text-sm font-semibold">${action.title}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">${action.description}</span>
+        </div>
+      </div>
+      ${
+        action.shortcut
+          ? `<span class="text-xs font-medium text-gray-400 dark:text-gray-500">${action.shortcut}</span>`
+          : ''
+      }
+    `;
+    if (!action.disabled) {
+      item.addEventListener('click', () => executeCommand(action.id));
+    }
+    item.addEventListener('mouseenter', () => {
+      if (action.disabled) return;
+      commandPaletteState.activeIndex = index;
+      updateCommandPaletteActive();
+    });
+    fragment.appendChild(item);
+  });
+  elements.commandPaletteList.appendChild(fragment);
+  updateCommandPaletteActive();
+};
+
+const filterCommandPaletteItems = (query) => {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    commandPaletteState.filtered = commandPaletteState.items.slice();
+    const firstEnabled = commandPaletteState.filtered.findIndex((item) => !item.disabled);
+    commandPaletteState.activeIndex = firstEnabled >= 0 ? firstEnabled : 0;
+    renderCommandPaletteItems();
+    return;
+  }
+  commandPaletteState.filtered = commandPaletteState.items.filter((action) => {
+    const haystack = `${action.title} ${action.description} ${action.keywords || ''}`.toLowerCase();
+    return haystack.includes(normalized);
+  });
+  const firstEnabled = commandPaletteState.filtered.findIndex((item) => !item.disabled);
+  commandPaletteState.activeIndex = firstEnabled >= 0 ? firstEnabled : 0;
+  renderCommandPaletteItems();
+};
+
+const closeCommandPalette = () => {
+  if (!commandPaletteState.isOpen) return;
+  setHidden(elements.commandPalette, true);
+  elements.commandPalette?.setAttribute('aria-hidden', 'true');
+  elements.commandPaletteButton?.setAttribute('aria-expanded', 'false');
+  document.body.classList.remove('overflow-hidden');
+  commandPaletteState.isOpen = false;
+  commandPaletteState.activeIndex = 0;
+  if (elements.commandPaletteSearch) {
+    elements.commandPaletteSearch.value = '';
+  }
+  if (commandPaletteState.returnFocusTo?.focus) {
+    commandPaletteState.returnFocusTo.focus();
+  }
+  commandPaletteState.returnFocusTo = null;
+};
+
+const openCommandPalette = () => {
+  commandPaletteState.items = computeCommandItems();
+  commandPaletteState.filtered = commandPaletteState.items.slice();
+  const firstEnabled = commandPaletteState.filtered.findIndex((item) => !item.disabled);
+  commandPaletteState.activeIndex = firstEnabled >= 0 ? firstEnabled : 0;
+  commandPaletteState.returnFocusTo = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  setHidden(elements.commandPalette, false);
+  elements.commandPalette?.setAttribute('aria-hidden', 'false');
+  elements.commandPaletteButton?.setAttribute('aria-expanded', 'true');
+  document.body.classList.add('overflow-hidden');
+  commandPaletteState.isOpen = true;
+  renderCommandPaletteItems();
+  if (elements.commandPaletteSearch) {
+    elements.commandPaletteSearch.value = '';
+    setTimeout(() => elements.commandPaletteSearch?.focus(), 60);
+  }
+};
+
+const moveCommandSelection = (direction) => {
+  if (!commandPaletteState.filtered.length) return;
+  const total = commandPaletteState.filtered.length;
+  let nextIndex = (commandPaletteState.activeIndex + direction + total) % total;
+  let safety = 0;
+  while (commandPaletteState.filtered[nextIndex]?.disabled && safety < total) {
+    nextIndex = (nextIndex + direction + total) % total;
+    safety += 1;
+  }
+  commandPaletteState.activeIndex = nextIndex;
+  updateCommandPaletteActive();
+};
+
+const executeCommand = async (commandId) => {
+  const action =
+    commandPaletteState.filtered.find((item) => item.id === commandId) ||
+    commandPaletteState.items.find((item) => item.id === commandId) ||
+    COMMAND_ACTIONS.find((item) => item.id === commandId);
+  if (!action || action.disabled) return;
+  closeCommandPalette();
+
+  switch (commandId) {
+    case 'focus-search':
+      elements.searchInput?.focus();
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: 'Kolom pencarian siap digunakan.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1200);
+      break;
+    case 'toggle-theme': {
+      const resolved = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+      const nextTheme = resolved === 'dark' ? 'light' : 'dark';
+      preferencesStore.setTheme(nextTheme);
+      applyTheme(nextTheme);
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: nextTheme === 'dark' ? 'Mode gelap diaktifkan.' : 'Mode terang diaktifkan.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1500);
+      break;
+    }
+    case 'toggle-density': {
+      const current = preferencesStore.getState().density;
+      const nextDensity = current === 'compact' ? 'comfortable' : 'compact';
+      preferencesStore.setDensity(nextDensity);
+      updateDensityToggle(elements.densityToggle, nextDensity);
+      applyArticles(uiState.articles);
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: nextDensity === 'compact' ? 'Mode padat aktif.' : 'Mode ruang lega aktif.',
+      });
+      break;
+    }
+    case 'view-grid':
+      preferencesStore.setViewMode('grid');
+      updateViewToggle(elements.viewToggle, 'grid');
+      applyArticles(uiState.articles);
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: 'Tampilan grid diaktifkan.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1200);
+      break;
+    case 'view-list':
+      preferencesStore.setViewMode('list');
+      updateViewToggle(elements.viewToggle, 'list');
+      applyArticles(uiState.articles);
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: 'Tampilan daftar diaktifkan.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1200);
+      break;
+    case 'open-trending':
+      document.getElementById('trending')?.scrollIntoView({ behavior: preferReducedMotion() ? 'auto' : 'smooth' });
+      break;
+    case 'open-saved-filters':
+      document.getElementById('savedFiltersList')?.scrollIntoView({ behavior: preferReducedMotion() ? 'auto' : 'smooth' });
+      break;
+    case 'refresh-articles':
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'info',
+        message: 'Menyegarkan berita terbaru...',
+      });
+      await fetchAndRender({ page: uiState.page });
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: navigator.onLine ? 'success' : 'error',
+        message: navigator.onLine ? 'Berita diperbarui.' : 'Menampilkan data terakhir dari cache.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1400);
+      break;
+    default:
+      break;
+  }
+};
+
+const isEditableElement = (element) => {
+  if (!element) return false;
+  if (element.isContentEditable) return true;
+  const tag = element.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+};
+
+const initCommandPalette = () => {
+  elements.commandPaletteButton?.addEventListener('click', () => {
+    if (commandPaletteState.isOpen) {
+      closeCommandPalette();
     } else {
-      element.classList.remove('hidden');
+      openCommandPalette();
     }
-  };
-
-  const resetMessages = () => {
-    setHidden(errorMessage, true);
-    setHidden(noResultsMessage, true);
-  };
-
-  const showError = (message) => {
-    if (!errorMessage) return;
-    errorMessage.textContent = message;
-    setHidden(errorMessage, false);
-    setHidden(noResultsMessage, true);
-  };
-
-  const showNoResults = () => {
-    setHidden(noResultsMessage, false);
-    setHidden(errorMessage, true);
-  };
-
-  const showLoading = () => {
-    setHidden(loadingIndicator, false);
-    resetMessages();
-    if (newsGrid) {
-      newsGrid.innerHTML = '';
+  });
+  elements.commandPaletteOverlay?.addEventListener('click', closeCommandPalette);
+  elements.commandPaletteClose?.addEventListener('click', closeCommandPalette);
+  elements.commandPaletteSearch?.addEventListener('input', (event) => {
+    filterCommandPaletteItems(event.target.value);
+  });
+  elements.commandPaletteSearch?.addEventListener('keydown', (event) => {
+    if (!commandPaletteState.isOpen) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveCommandSelection(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveCommandSelection(-1);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const current = commandPaletteState.filtered[commandPaletteState.activeIndex];
+      if (current && !current.disabled) {
+        executeCommand(current.id);
+      }
     }
-  };
+  });
 
-  const hideLoading = () => {
-    setHidden(loadingIndicator, true);
-  };
-
-  const renderNews = (articles) => {
-    if (!newsGrid) return;
-    newsGrid.innerHTML = '';
-
-    if (!articles || articles.length === 0) {
-      showNoResults();
+  window.addEventListener('keydown', (event) => {
+    const key = event.key.toLowerCase();
+    if ((event.metaKey || event.ctrlKey) && key === 'k') {
+      event.preventDefault();
+      if (commandPaletteState.isOpen) {
+        closeCommandPalette();
+      } else {
+        openCommandPalette();
+      }
       return;
     }
-
-    const fragment = document.createDocumentFragment();
-
-    articles.forEach((article) => {
-      const { image, title, publishedAt, description, url, source } = article;
-      const card = document.createElement('article');
-      card.setAttribute('tabindex', '0');
-      card.className =
-        'flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500';
-
-      const imgWrapper = document.createElement('div');
-      imgWrapper.className = 'w-full aspect-[3/2] overflow-hidden bg-gray-200 dark:bg-gray-700';
-
-      const img = document.createElement('img');
-      img.src = image || defaultImage;
-      img.alt = title || 'Gambar berita';
-      img.loading = 'lazy';
-      img.className = 'object-cover w-full h-full';
-      imgWrapper.appendChild(img);
-
-      const content = document.createElement('div');
-      content.className = 'flex flex-col flex-grow p-4';
-
-      const heading = document.createElement('h2');
-      heading.className = 'text-lg font-semibold mb-2 line-clamp-2 text-gray-900 dark:text-gray-100';
-      heading.textContent = title || 'Judul berita tidak tersedia';
-
-      const meta = document.createElement('p');
-      meta.className = 'text-sm text-gray-500 dark:text-gray-400 mb-3 select-none';
-      meta.textContent = formatDate(publishedAt);
-      if (source && source.name) {
-        meta.textContent += ` • ${source.name}`;
+    if (!commandPaletteState.isOpen) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeCommandPalette();
+      return;
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveCommandSelection(1);
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveCommandSelection(-1);
+      return;
+    }
+    if (event.key === 'Enter' && document.activeElement !== elements.commandPaletteSearch) {
+      event.preventDefault();
+      const current = commandPaletteState.filtered[commandPaletteState.activeIndex];
+      if (current && !current.disabled) {
+        executeCommand(current.id);
       }
+    }
+  });
+};
 
-      const descriptionEl = document.createElement('p');
-      descriptionEl.className = 'text-gray-700 dark:text-gray-300 flex-grow line-clamp-3 mb-4';
-      descriptionEl.textContent = description || 'Deskripsi berita tidak tersedia.';
+const initKeyboardShortcuts = () => {
+  window.addEventListener('keydown', (event) => {
+    if (commandPaletteState.isOpen) return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    const active = document.activeElement;
+    const editing = isEditableElement(active);
+    if (event.key === '/' && !editing) {
+      event.preventDefault();
+      elements.searchInput?.focus();
+      return;
+    }
+    if ((event.key === 't' || event.key === 'T') && !editing) {
+      event.preventDefault();
+      executeCommand('toggle-theme');
+      return;
+    }
+    if ((event.key === 'r' || event.key === 'R') && !editing) {
+      event.preventDefault();
+      executeCommand('refresh-articles');
+    }
+  });
+};
 
-      const link = document.createElement('a');
-      link.href = url || '#';
-      link.target = '_blank';
-      link.rel = 'noopener noreferrer';
-      link.className =
-        'inline-block mt-auto self-start bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white font-semibold rounded-md px-4 py-2 transition focus:outline-none focus:ring-2 focus:ring-blue-500';
-      link.textContent = 'Baca Selengkapnya';
-
-      content.appendChild(heading);
-      content.appendChild(meta);
-      content.appendChild(descriptionEl);
-      content.appendChild(link);
-
-      card.appendChild(imgWrapper);
-      card.appendChild(content);
-      fragment.appendChild(card);
+const initRefreshControl = () => {
+  elements.refreshArticles?.addEventListener('click', async () => {
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: 'info',
+      message: 'Menyegarkan berita terbaru...',
     });
-
-    newsGrid.appendChild(fragment);
-  };
-
-  const updatePagination = () => {
-    const totalPages = Math.max(1, Math.ceil(totalResults / PAGE_SIZE));
-    pageInfo.textContent = `Halaman ${currentPage} dari ${totalPages}`;
-    const canGoPrev = currentPage > 1;
-    const canGoNext = currentPage < totalPages;
-
-    prevPageBtn.disabled = !canGoPrev;
-    nextPageBtn.disabled = !canGoNext;
-
-    prevPageBtn.setAttribute('aria-disabled', String(!canGoPrev));
-    nextPageBtn.setAttribute('aria-disabled', String(!canGoNext));
-  };
-
-  const fetchNews = async () => {
-    showLoading();
-
-    const params = new URLSearchParams({
-      query: currentQuery,
-      category: currentCategory,
-      page: String(currentPage),
-      pageSize: String(PAGE_SIZE),
+    await fetchAndRender({ page: uiState.page });
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: navigator.onLine ? 'success' : 'error',
+      message: navigator.onLine ? 'Berita diperbarui.' : 'Menampilkan data terakhir dari cache.',
     });
+    setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1400);
+  });
+};
 
-    try {
-      const response = await fetch(`/api/news?${params.toString()}`, {
-        headers: {
-          Accept: 'application/json',
-        },
+const initScrollProgress = () => {
+  const updateProgress = () => {
+    if (elements.scrollProgress) {
+      const doc = document.documentElement;
+      const max = doc.scrollHeight - doc.clientHeight;
+      const percent = max > 0 ? (window.scrollY / max) * 100 : 0;
+      elements.scrollProgress.style.width = `${percent}%`;
+    }
+    if (elements.backToTop) {
+      const show = window.scrollY > 320;
+      toggleClass(elements.backToTop, 'opacity-0', !show);
+      toggleClass(elements.backToTop, 'pointer-events-none', !show);
+    }
+  };
+  updateProgress();
+  window.addEventListener('scroll', updateProgress, { passive: true });
+  elements.backToTop?.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: preferReducedMotion() ? 'auto' : 'smooth' });
+  });
+};
+
+const initPreferenceSync = () => {
+  preferencesStore.subscribe((state) => {
+    updateViewToggle(elements.viewToggle, state.viewMode);
+    updateDensityToggle(elements.densityToggle, state.density);
+  });
+};
+
+const fillSelectOptions = () => {
+  if (elements.categorySelect) {
+    elements.categorySelect.innerHTML = CATEGORY_OPTIONS.map(
+      (option) => `<option value="${option.value}">${option.label}</option>`,
+    ).join('');
+  }
+  if (elements.sortBySelect) {
+    elements.sortBySelect.innerHTML = SORT_OPTIONS.map(
+      (option) => `<option value="${option.value}">${option.label}</option>`,
+    ).join('');
+  }
+  if (elements.timeRangeSelect) {
+    elements.timeRangeSelect.innerHTML = TIME_RANGE_OPTIONS.map(
+      (option) => `<option value="${option.value}">${option.label}</option>`,
+    ).join('');
+  }
+  if (elements.pageSizeSelect) {
+    elements.pageSizeSelect.innerHTML = PAGE_SIZE_OPTIONS.map(
+      (value) => `<option value="${value}">${value} / halaman</option>`,
+    ).join('');
+  }
+};
+
+const resetFeedback = () => {
+  setHidden(elements.errorMessage, true);
+  setHidden(elements.noResultsMessage, true);
+};
+
+const showError = (message) => {
+  if (!elements.errorMessage) return;
+  elements.errorMessage.textContent = message;
+  setHidden(elements.errorMessage, false);
+  setHidden(elements.noResultsMessage, true);
+};
+
+const showNoResults = () => {
+  if (!elements.noResultsMessage) return;
+  setHidden(elements.noResultsMessage, false);
+  setHidden(elements.errorMessage, true);
+  if (elements.resultSummary) {
+    elements.resultSummary.textContent = 'Tidak ada artikel untuk filter yang dipilih.';
+  }
+  renderFeaturedArticle(elements.featuredArticle, null);
+  const { viewMode, density } = preferencesStore.getState();
+  renderArticles({ container: elements.newsGrid, articles: [], viewMode, density });
+};
+
+const updatePagination = () => {
+  const { pageSize, viewMode } = preferencesStore.getState();
+  const totalPages = Math.max(1, Math.ceil(uiState.totalResults / pageSize));
+  elements.prevPage?.setAttribute('aria-disabled', uiState.page <= 1);
+  elements.nextPage?.setAttribute('aria-disabled', uiState.page >= totalPages);
+  elements.prevPage?.classList.toggle('opacity-50', uiState.page <= 1);
+  elements.nextPage?.classList.toggle('opacity-50', uiState.page >= totalPages);
+  if (elements.prevPage) elements.prevPage.disabled = uiState.page <= 1;
+  if (elements.nextPage) elements.nextPage.disabled = uiState.page >= totalPages;
+  if (elements.pageInfo) {
+    elements.pageInfo.textContent = `Halaman ${uiState.page} dari ${totalPages}`;
+  }
+  if (elements.resultSummary) {
+    const showingFrom = (uiState.page - 1) * pageSize + 1;
+    const showingTo = Math.min(uiState.page * pageSize, uiState.totalResults);
+    if (uiState.totalResults === 0) {
+      elements.resultSummary.textContent = 'Tidak ada artikel untuk filter yang dipilih.';
+    } else {
+      elements.resultSummary.textContent = `Menampilkan ${showingFrom} - ${showingTo} dari ${uiState.totalResults.toLocaleString('id-ID')} artikel`;
+    }
+  }
+  const activeFilters = [uiState.latestQuery || 'Semua berita', preferencesStore.getState().category || 'Semua kategori'];
+  if (preferencesStore.getState().timeRange && preferencesStore.getState().timeRange !== 'all') {
+    activeFilters.push(`Rentang ${preferencesStore.getState().timeRange}`);
+  }
+  renderStats({
+    totalArticlesStat: elements.totalArticlesStat,
+    activeFiltersStat: elements.activeFiltersStat,
+    lastUpdatedStat: elements.lastUpdatedStat,
+    total: uiState.totalResults,
+    activeFilters: activeFilters.join(' • '),
+    lastUpdated: uiState.lastUpdated,
+  });
+  updateViewToggle(elements.viewToggle, viewMode);
+};
+
+const showLoading = () => {
+  uiState.isLoading = true;
+  setHidden(elements.loadingIndicator, false);
+  resetFeedback();
+  const { viewMode, pageSize, density } = preferencesStore.getState();
+  renderSkeletons({
+    container: elements.newsGrid,
+    viewMode,
+    count: pageSize,
+    density,
+  });
+};
+
+const hideLoading = () => {
+  uiState.isLoading = false;
+  setHidden(elements.loadingIndicator, true);
+};
+
+const applyShareListeners = () => {
+  qsa('.share-button').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const url = button.dataset.url;
+      const title = button.dataset.title || 'Berita menarik di NewsApp';
+      if (navigator.share) {
+        try {
+          await navigator.share({ title, url });
+          updateStatusBanner(elements.statusBanner, {
+            online: true,
+            tone: 'success',
+            message: 'Tautan berhasil dibagikan!',
+          });
+          setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1800);
+          return;
+        } catch (error) {
+          if (error?.name === 'AbortError') return;
+        }
+      }
+      try {
+        await navigator.clipboard.writeText(url);
+        updateStatusBanner(elements.statusBanner, {
+          online: true,
+          tone: 'success',
+          message: 'Tautan disalin ke papan klip.',
+        });
+        setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1800);
+      } catch (error) {
+        updateStatusBanner(elements.statusBanner, {
+          online: true,
+          tone: 'error',
+          message: 'Gagal menyalin tautan. Silakan salin manual.',
+        });
+      }
+    });
+  });
+};
+
+const hydrateFormFromPreferences = () => {
+  const preferences = preferencesStore.getState();
+  if (elements.categorySelect) elements.categorySelect.value = preferences.category;
+  if (elements.sortBySelect) elements.sortBySelect.value = preferences.sortBy;
+  if (elements.timeRangeSelect) elements.timeRangeSelect.value = preferences.timeRange;
+  if (elements.pageSizeSelect) elements.pageSizeSelect.value = String(preferences.pageSize);
+  if (elements.searchInput) elements.searchInput.value = preferences.lastQuery;
+  updateViewToggle(elements.viewToggle, preferences.viewMode);
+  updateDensityToggle(elements.densityToggle, preferences.density);
+};
+
+const applyArticles = (articles) => {
+  const { viewMode, density } = preferencesStore.getState();
+  renderArticles({ container: elements.newsGrid, articles, viewMode, density });
+  applyShareListeners();
+};
+
+const hydrateSavedFilters = () => {
+  renderSavedFilters(elements.savedFiltersList, savedFiltersStore.getAll(), {
+    onSelect: (filter) => {
+      preferencesStore.setCategory(filter.category);
+      preferencesStore.setSortBy(filter.sortBy);
+      preferencesStore.setTimeRange(filter.timeRange);
+      preferencesStore.setPageSize(filter.pageSize);
+      preferencesStore.setLastQuery(filter.query);
+      if (elements.searchInput) elements.searchInput.value = filter.query;
+      hydrateFormFromPreferences();
+      fetchAndRender({ page: 1 });
+    },
+    onDelete: (filter) => {
+      savedFiltersStore.remove(filter.name);
+      hydrateSavedFilters();
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: `Filter "${filter.name}" dihapus.`,
       });
+    },
+  });
+};
 
-      if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({}));
-        const message = errorBody.message || `Gagal mengambil data: ${response.status}`;
-        throw new Error(message);
-      }
+const syncOfflineBadge = () => {
+  if (!elements.offlineBadge) return;
+  const online = navigator.onLine;
+  toggleClass(elements.offlineBadge, 'hidden', online);
+  if (!online) {
+    elements.offlineBadge.textContent = 'Mode offline: menampilkan data terakhir';
+  }
+};
 
-      const data = await response.json();
-      totalResults = data.totalArticles || 0;
-      renderNews(data.articles);
-      updatePagination();
-    } catch (error) {
-      console.error(error); // eslint-disable-line no-console
-      showError(error.message || 'Terjadi kesalahan saat mengambil berita.');
-      pageInfo.textContent = '';
-    } finally {
+const fetchAndRender = async ({ page = uiState.page, query } = {}) => {
+  const preferences = preferencesStore.getState();
+  const currentQuery = typeof query === 'string' ? query : elements.searchInput?.value || preferences.lastQuery;
+  uiState.page = page;
+  uiState.latestQuery = currentQuery;
+  preferencesStore.setLastQuery(currentQuery);
+
+  showLoading();
+  try {
+    const response = await newsClient.fetchNews({
+      query: currentQuery,
+      category: preferences.category,
+      sortBy: preferences.sortBy,
+      timeRange: preferences.timeRange,
+      page,
+      pageSize: preferences.pageSize,
+    });
+    const articles = response.articles || [];
+    if (!articles.length) {
+      uiState.totalResults = 0;
+      uiState.articles = [];
       hideLoading();
+      showNoResults();
+      updatePagination();
+      return;
+    }
+    uiState.totalResults = response.totalArticles ?? articles.length;
+    uiState.articles = articles;
+    uiState.lastUpdated = new Date();
+    hideLoading();
+    resetFeedback();
+    renderFeaturedArticle(elements.featuredArticle, articles[0]);
+    applyArticles(articles);
+    updatePagination();
+  } catch (error) {
+    console.error('Gagal memuat berita', error);
+    hideLoading();
+    if (!navigator.onLine) {
+      const fallback = newsClient.getOfflineFallback();
+      if (fallback?.payload?.articles?.length) {
+        uiState.totalResults = fallback.payload.totalArticles ?? fallback.payload.articles.length;
+        uiState.articles = fallback.payload.articles;
+        uiState.lastUpdated = fallback.persistedAt ? new Date(fallback.persistedAt) : null;
+        renderFeaturedArticle(elements.featuredArticle, uiState.articles[0]);
+        applyArticles(uiState.articles);
+        updatePagination();
+        updateStatusBanner(elements.statusBanner, {
+          online: false,
+          tone: 'error',
+          message: 'Anda sedang offline. Menampilkan cache terakhir.',
+        });
+        return;
+      }
+    }
+    showError(error?.message || 'Terjadi kesalahan saat memuat berita.');
+  }
+};
+
+const handleSearchSubmit = (event) => {
+  event?.preventDefault();
+  uiState.page = 1;
+  fetchAndRender({ page: 1 });
+};
+
+const initQuickFilters = () => {
+  elements.quickFilters.forEach((button) => {
+    button.addEventListener('click', () => {
+      const query = button.dataset.query || '';
+      if (elements.searchInput) elements.searchInput.value = query;
+      preferencesStore.setLastQuery(query);
+      uiState.page = 1;
+      fetchAndRender({ page: 1, query });
+    });
+  });
+};
+
+const initCategoryPills = () => {
+  elements.categoryPills.forEach((pill) => {
+    pill.addEventListener('click', () => {
+      const category = pill.dataset.category || '';
+      preferencesStore.setCategory(category);
+      if (elements.categorySelect) elements.categorySelect.value = category;
+      uiState.page = 1;
+      fetchAndRender({ page: 1 });
+    });
+  });
+};
+
+const initPagination = () => {
+  elements.prevPage?.addEventListener('click', () => {
+    if (uiState.page <= 1 || uiState.isLoading) return;
+    fetchAndRender({ page: uiState.page - 1 });
+  });
+  elements.nextPage?.addEventListener('click', () => {
+    const totalPages = Math.max(1, Math.ceil(uiState.totalResults / preferencesStore.getState().pageSize));
+    if (uiState.page >= totalPages || uiState.isLoading) return;
+    fetchAndRender({ page: uiState.page + 1 });
+  });
+};
+
+const initViewToggle = () => {
+  qsa('button[data-view]', elements.viewToggle).forEach((button) => {
+    button.addEventListener('click', () => {
+      const view = button.dataset.view;
+      preferencesStore.setViewMode(view);
+      updateViewToggle(elements.viewToggle, view);
+      applyArticles(uiState.articles);
+    });
+  });
+};
+
+const initReadingDensityToggle = () => {
+  updateDensityToggle(elements.densityToggle, preferencesStore.getState().density);
+  elements.densityToggle?.addEventListener('click', () => {
+    const current = preferencesStore.getState().density;
+    const nextDensity = current === 'compact' ? 'comfortable' : 'compact';
+    preferencesStore.setDensity(nextDensity);
+    updateDensityToggle(elements.densityToggle, nextDensity);
+    applyArticles(uiState.articles);
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: 'success',
+      message: nextDensity === 'compact' ? 'Mode padat aktif.' : 'Mode ruang lega aktif.',
+    });
+    setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1500);
+  });
+};
+
+const initFormHandlers = () => {
+  elements.searchForm?.addEventListener('submit', handleSearchSubmit);
+  elements.categorySelect?.addEventListener('change', (event) => {
+    preferencesStore.setCategory(event.target.value);
+    fetchAndRender({ page: 1 });
+  });
+  elements.sortBySelect?.addEventListener('change', (event) => {
+    preferencesStore.setSortBy(event.target.value);
+    fetchAndRender({ page: 1 });
+  });
+  elements.timeRangeSelect?.addEventListener('change', (event) => {
+    preferencesStore.setTimeRange(event.target.value);
+    fetchAndRender({ page: 1 });
+  });
+  elements.pageSizeSelect?.addEventListener('change', (event) => {
+    preferencesStore.setPageSize(Number(event.target.value));
+    fetchAndRender({ page: 1 });
+  });
+};
+
+const initSavedFilters = () => {
+  hydrateSavedFilters();
+  elements.saveCurrentFilter?.addEventListener('click', () => {
+    const name = elements.savedFilterName?.value?.trim() ?? '';
+    if (!name) {
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'error',
+        message: 'Nama filter tidak boleh kosong.',
+      });
+      return;
+    }
+    const preferences = preferencesStore.getState();
+    const saved = savedFiltersStore.add({
+      name,
+      query: preferences.lastQuery,
+      category: preferences.category,
+      sortBy: preferences.sortBy,
+      timeRange: preferences.timeRange,
+      pageSize: preferences.pageSize,
+    });
+    if (saved && elements.savedFilterName) {
+      elements.savedFilterName.value = '';
+      hydrateSavedFilters();
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: `Filter "${name}" tersimpan!`,
+      });
+    }
+  });
+  elements.clearSavedFilters?.addEventListener('click', () => {
+    savedFiltersStore.clear();
+    hydrateSavedFilters();
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: 'success',
+      message: 'Semua filter tersimpan dihapus.',
+    });
+  });
+};
+
+const initThemeToggle = () => {
+  applyTheme(preferencesStore.getState().theme);
+  elements.darkModeToggle?.addEventListener('click', () => {
+    const current = preferencesStore.getState().theme;
+    const nextTheme = current === 'dark' ? 'light' : 'dark';
+    preferencesStore.setTheme(nextTheme);
+    applyTheme(nextTheme);
+  });
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (preferencesStore.getState().theme === 'system') {
+      applyTheme('system');
+    }
+  });
+};
+
+const initMobileMenu = () => {
+  elements.mobileMenuButton?.addEventListener('click', () => {
+    const expanded = elements.mobileMenuButton.getAttribute('aria-expanded') === 'true';
+    elements.mobileMenuButton.setAttribute('aria-expanded', String(!expanded));
+    toggleClass(elements.mobileMenu, 'hidden', expanded);
+    if (!expanded && !preferReducedMotion()) {
+      elements.mobileMenu?.animate(
+        [
+          { opacity: 0, transform: 'translateY(-8px)' },
+          { opacity: 1, transform: 'translateY(0)' },
+        ],
+        { duration: 200, easing: 'ease-out' },
+      );
+    }
+  });
+  qsa('#mobileMenu a').forEach((link) =>
+    link.addEventListener('click', () => {
+      elements.mobileMenuButton?.setAttribute('aria-expanded', 'false');
+      toggleClass(elements.mobileMenu, 'hidden', true);
+    }),
+  );
+  qs('[data-open-command-palette]', elements.mobileMenu)?.addEventListener('click', () => {
+    elements.mobileMenuButton?.setAttribute('aria-expanded', 'false');
+    toggleClass(elements.mobileMenu, 'hidden', true);
+    openCommandPalette();
+  });
+};
+
+const initTrending = () => {
+  const handleIdeaSelect = (idea) => {
+    if (elements.searchInput) elements.searchInput.value = idea.query;
+    preferencesStore.setLastQuery(idea.query);
+    uiState.page = 1;
+    fetchAndRender({ page: 1, query: idea.query });
+  };
+  renderTrendingTopics(elements.trendingTopics, handleIdeaSelect);
+  renderNicheFocus(elements.nicheTopics, handleIdeaSelect);
+  elements.refreshTrending?.addEventListener('click', () => {
+    renderTrendingTopics(elements.trendingTopics, handleIdeaSelect);
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: 'success',
+      message: 'Topik trending diperbarui.',
+    });
+    setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1500);
+  });
+};
+
+const initNetworkListeners = () => {
+  const syncStatus = () => {
+    const online = navigator.onLine;
+    syncOfflineBadge();
+    updateStatusBanner(elements.statusBanner, {
+      online,
+      tone: online ? 'success' : 'error',
+      message: online ? 'Terhubung ke internet.' : 'Koneksi terputus. Beberapa fitur dibatasi.',
+    });
+    if (online) {
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1500);
     }
   };
+  window.addEventListener('online', syncStatus);
+  window.addEventListener('offline', syncStatus);
+  syncStatus();
+};
 
-  searchForm.addEventListener('submit', (event) => {
-    event.preventDefault();
-    currentQuery = searchInput.value.trim();
-    currentPage = 1;
-    fetchNews();
+const initAccessibility = () => {
+  qsa('a[href^="#"]').forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const targetId = link.getAttribute('href')?.slice(1);
+      const target = targetId ? document.getElementById(targetId) : null;
+      if (target) {
+        event.preventDefault();
+        target.scrollIntoView({ behavior: preferReducedMotion() ? 'auto' : 'smooth' });
+        target.focus?.({ preventScroll: true });
+      }
+    });
   });
+};
 
-  categorySelect.addEventListener('change', () => {
-    currentCategory = categorySelect.value;
-    currentPage = 1;
-    fetchNews();
-  });
+const initApp = () => {
+  fillSelectOptions();
+  hydrateFormFromPreferences();
+  initFormHandlers();
+  initQuickFilters();
+  initCategoryPills();
+  initPagination();
+  initViewToggle();
+  initReadingDensityToggle();
+  initSavedFilters();
+  initThemeToggle();
+  initMobileMenu();
+  initTrending();
+  initRefreshControl();
+  initCommandPalette();
+  initKeyboardShortcuts();
+  initScrollProgress();
+  initNetworkListeners();
+  initAccessibility();
+  initPreferenceSync();
+  syncOfflineBadge();
+  fetchAndRender({ page: 1 });
+};
 
-  prevPageBtn.addEventListener('click', () => {
-    if (currentPage > 1) {
-      currentPage -= 1;
-      fetchNews();
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-  });
-
-  nextPageBtn.addEventListener('click', () => {
-    const totalPages = Math.ceil(totalResults / PAGE_SIZE);
-    if (currentPage < totalPages) {
-      currentPage += 1;
-      fetchNews();
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-  });
-
-  const setDarkMode = (enabled) => {
-    const root = document.documentElement;
-    if (enabled) {
-      root.classList.add('dark');
-      localStorage.setItem('darkMode', 'true');
-      darkModeToggle.innerHTML = '<i class="fas fa-sun"></i>';
-      darkModeToggle.setAttribute('aria-label', 'Matikan mode gelap');
-      darkModeToggle.title = 'Matikan mode gelap';
-    } else {
-      root.classList.remove('dark');
-      localStorage.setItem('darkMode', 'false');
-      darkModeToggle.innerHTML = '<i class="fas fa-moon"></i>';
-      darkModeToggle.setAttribute('aria-label', 'Nyalakan mode gelap');
-      darkModeToggle.title = 'Nyalakan mode gelap';
-    }
-  };
-
-  darkModeToggle.addEventListener('click', () => {
-    const isDark = document.documentElement.classList.contains('dark');
-    setDarkMode(!isDark);
-  });
-
-  (() => {
-    const saved = localStorage.getItem('darkMode');
-    if (saved === 'true') {
-      setDarkMode(true);
-    } else if (saved === 'false') {
-      setDarkMode(false);
-    } else {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setDarkMode(prefersDark);
-    }
-  })();
-
-  mobileMenuButton.addEventListener('click', () => {
-    if (mobileMenu.classList.contains('hidden')) {
-      mobileMenu.classList.remove('hidden');
-      mobileMenuButton.setAttribute('aria-expanded', 'true');
-    } else {
-      mobileMenu.classList.add('hidden');
-      mobileMenuButton.setAttribute('aria-expanded', 'false');
-    }
-  });
-
-  fetchNews();
-})();
+window.addEventListener('DOMContentLoaded', initApp);

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,6 +14,7 @@ import {
   renderNicheFocus,
   renderSavedFilters,
   renderSkeletons,
+  renderSecurityHighlights,
   renderStats,
   renderTrendingTopics,
   updateStatusBanner,
@@ -21,10 +22,11 @@ import {
   updateDensityToggle,
 } from './ui.renderers.js';
 import { preferReducedMotion, qsa, qs, setHidden, toggleClass } from './utils.dom.js';
+import { generateIntegrityHash, isSecureStorageSupported, maskFingerprint } from './utils.security.js';
 
 const newsClient = createNewsClient();
-const preferencesStore = createPreferencesStore();
-const savedFiltersStore = createSavedFiltersStore();
+let preferencesStore;
+let savedFiltersStore;
 
 const elements = {
   newsGrid: qs('#newsGrid'),
@@ -70,6 +72,14 @@ const elements = {
   commandPaletteList: qs('#commandPaletteList'),
   backToTop: qs('#backToTop'),
   scrollProgress: qs('#scrollProgress'),
+  securityHighlights: qs('#securityHighlights'),
+  securityStatusBadge: qs('#securityStatusBadge'),
+  securityFingerprint: qs('#securityFingerprint'),
+  securityUpdatedAt: qs('#securityUpdatedAt'),
+  securitySupportMessage: qs('#securitySupportMessage'),
+  integrityStatus: qs('#integrityStatus'),
+  integrityCheckButton: qs('#integrityCheckButton'),
+  copyFingerprintButton: qs('#copyFingerprintButton'),
 };
 
 const uiState = {
@@ -106,9 +116,23 @@ const applyTheme = (theme = 'system') => {
   }
 };
 
+const securityState = {
+  supported: isSecureStorageSupported(),
+  fingerprint: '',
+  lastIntegrityHash: '',
+  lastIntegrityCheck: null,
+  lastPreferencesUpdate: null,
+};
+
+const formatTimestamp = (date) => {
+  if (!date) return '-';
+  return new Intl.DateTimeFormat('id-ID', { dateStyle: 'medium', timeStyle: 'medium' }).format(date);
+};
+
 const computeCommandItems = () => {
   const resolvedTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
-  const { density, viewMode } = preferencesStore.getState();
+  const preferences = preferencesStore?.getState?.() || { density: 'comfortable', viewMode: 'grid' };
+  const { density, viewMode } = preferences;
   return COMMAND_ACTIONS.map((action) => {
     const item = { ...action };
     switch (action.id) {
@@ -138,10 +162,158 @@ const computeCommandItems = () => {
           item.description = 'Saat ini Anda sudah menggunakan tampilan daftar.';
         }
         break;
+      case 'run-integrity-check':
+        if (securityState.lastIntegrityCheck) {
+          item.description = `Fingerprint terakhir diperbarui ${formatTimestamp(securityState.lastIntegrityCheck)}.`;
+        }
+        break;
       default:
         break;
     }
     return item;
+  });
+};
+
+const updateSecuritySupport = () => {
+  if (elements.securityStatusBadge) {
+    const badge = elements.securityStatusBadge;
+    badge.classList.remove(
+      'bg-emerald-100',
+      'text-emerald-700',
+      'dark:bg-emerald-500/20',
+      'dark:text-emerald-200',
+      'bg-amber-100',
+      'text-amber-700',
+      'dark:bg-amber-500/20',
+      'dark:text-amber-200',
+    );
+    if (securityState.supported) {
+      badge.classList.add('bg-emerald-100', 'text-emerald-700', 'dark:bg-emerald-500/20', 'dark:text-emerald-200');
+      badge.textContent = 'Aktif';
+    } else {
+      badge.classList.add('bg-amber-100', 'text-amber-700', 'dark:bg-amber-500/20', 'dark:text-amber-200');
+      badge.textContent = 'Mode kompatibilitas';
+    }
+  }
+  if (elements.securitySupportMessage) {
+    elements.securitySupportMessage.textContent = securityState.supported
+      ? 'Penyimpanan terenkripsi aktif dengan AES-256 dan fingerprint SHA-256.'
+      : 'Web Crypto penuh tidak tersedia, sistem menggunakan sandi kompatibel untuk menjaga data.';
+  }
+};
+
+const toneClassMap = {
+  success: ['text-emerald-600', 'dark:text-emerald-300'],
+  error: ['text-red-600', 'dark:text-red-400'],
+  info: ['text-blue-600', 'dark:text-blue-300'],
+};
+
+const updateIntegrityStatus = (message, tone = 'info') => {
+  if (!elements.integrityStatus) return;
+  const element = elements.integrityStatus;
+  element.textContent = message;
+  Object.values(toneClassMap).forEach((classes) => element.classList.remove(...classes));
+  const classes = toneClassMap[tone] || toneClassMap.info;
+  element.classList.add(...classes);
+};
+
+const updateSecuritySummary = async () => {
+  if (!preferencesStore) return;
+  try {
+    const fingerprint = await generateIntegrityHash(preferencesStore.getState());
+    securityState.fingerprint = fingerprint;
+    securityState.lastPreferencesUpdate = new Date();
+    if (elements.securityFingerprint) {
+      elements.securityFingerprint.textContent = maskFingerprint(fingerprint);
+    }
+    if (elements.securityUpdatedAt) {
+      elements.securityUpdatedAt.textContent = formatTimestamp(securityState.lastPreferencesUpdate);
+    }
+  } catch (error) {
+    console.warn('Gagal memperbarui fingerprint preferensi', error);
+    if (elements.securityFingerprint) {
+      elements.securityFingerprint.textContent = 'Fingerprint tidak tersedia';
+    }
+  }
+  updateSecuritySupport();
+};
+
+const updateContentIntegrity = async (articles = uiState.articles) => {
+  if (!elements.integrityStatus) return;
+  if (!articles?.length) {
+    securityState.lastIntegrityHash = '';
+    securityState.lastIntegrityCheck = new Date();
+    updateIntegrityStatus('Menunggu data berita untuk dianalisis.', 'info');
+    return;
+  }
+  try {
+    const digest = await generateIntegrityHash(
+      articles
+        .map((article) => `${article.title || ''}|${article.publishedAt || ''}|${article.url || ''}`)
+        .join('||'),
+    );
+    securityState.lastIntegrityHash = digest;
+    securityState.lastIntegrityCheck = new Date();
+    updateIntegrityStatus(
+      `Fingerprint konten ${maskFingerprint(digest)} diperbarui ${formatTimestamp(securityState.lastIntegrityCheck)}.`,
+      'success',
+    );
+  } catch (error) {
+    console.warn('Gagal menghitung fingerprint konten', error);
+    updateIntegrityStatus('Fingerprint konten tidak dapat dihitung.', 'error');
+  }
+};
+
+const initSecurityPanel = () => {
+  renderSecurityHighlights(elements.securityHighlights);
+  updateSecuritySupport();
+  updateIntegrityStatus('Menunggu data berita untuk dianalisis.', 'info');
+  elements.integrityCheckButton?.addEventListener('click', async () => {
+    await updateContentIntegrity();
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: 'success',
+      message: 'Fingerprint konten diperbarui.',
+    });
+    setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1600);
+  });
+  elements.copyFingerprintButton?.addEventListener('click', async () => {
+    if (!securityState.fingerprint) {
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'error',
+        message: 'Fingerprint preferensi belum tersedia.',
+      });
+      return;
+    }
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(securityState.fingerprint);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = securityState.fingerprint;
+        textarea.setAttribute('readonly', 'true');
+        textarea.style.position = 'absolute';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: 'Fingerprint preferensi disalin ke clipboard.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1400);
+    } catch (error) {
+      console.warn('Gagal menyalin fingerprint', error);
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'error',
+        message: 'Tidak dapat menyalin fingerprint. Coba secara manual.',
+      });
+    }
   });
 };
 
@@ -323,6 +495,17 @@ const executeCommand = async (commandId) => {
         tone: 'success',
         message: nextDensity === 'compact' ? 'Mode padat aktif.' : 'Mode ruang lega aktif.',
       });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1500);
+      break;
+    }
+    case 'run-integrity-check': {
+      await updateContentIntegrity();
+      updateStatusBanner(elements.statusBanner, {
+        online: true,
+        tone: 'success',
+        message: 'Fingerprint konten diperbarui.',
+      });
+      setTimeout(() => updateStatusBanner(elements.statusBanner, { online: null, message: '', tone: 'info' }), 1800);
       break;
     }
     case 'view-grid':
@@ -511,6 +694,7 @@ const initPreferenceSync = () => {
   preferencesStore.subscribe((state) => {
     updateViewToggle(elements.viewToggle, state.viewMode);
     updateDensityToggle(elements.densityToggle, state.density);
+    updateSecuritySummary();
   });
 };
 
@@ -559,6 +743,7 @@ const showNoResults = () => {
   renderFeaturedArticle(elements.featuredArticle, null);
   const { viewMode, density } = preferencesStore.getState();
   renderArticles({ container: elements.newsGrid, articles: [], viewMode, density });
+  updateContentIntegrity([]);
 };
 
 const updatePagination = () => {
@@ -736,18 +921,20 @@ const fetchAndRender = async ({ page = uiState.page, query } = {}) => {
     resetFeedback();
     renderFeaturedArticle(elements.featuredArticle, articles[0]);
     applyArticles(articles);
+    await updateContentIntegrity(articles);
     updatePagination();
   } catch (error) {
     console.error('Gagal memuat berita', error);
     hideLoading();
     if (!navigator.onLine) {
-      const fallback = newsClient.getOfflineFallback();
+      const fallback = await newsClient.getOfflineFallback();
       if (fallback?.payload?.articles?.length) {
         uiState.totalResults = fallback.payload.totalArticles ?? fallback.payload.articles.length;
         uiState.articles = fallback.payload.articles;
         uiState.lastUpdated = fallback.persistedAt ? new Date(fallback.persistedAt) : null;
         renderFeaturedArticle(elements.featuredArticle, uiState.articles[0]);
         applyArticles(uiState.articles);
+        await updateContentIntegrity(uiState.articles);
         updatePagination();
         updateStatusBanner(elements.statusBanner, {
           online: false,
@@ -988,7 +1175,11 @@ const initAccessibility = () => {
   });
 };
 
-const initApp = () => {
+const initApp = async () => {
+  preferencesStore = await createPreferencesStore();
+  savedFiltersStore = await createSavedFiltersStore();
+  initSecurityPanel();
+  await updateSecuritySummary();
   fillSelectOptions();
   hydrateFormFromPreferences();
   initFormHandlers();
@@ -1009,7 +1200,17 @@ const initApp = () => {
   initAccessibility();
   initPreferenceSync();
   syncOfflineBadge();
-  fetchAndRender({ page: 1 });
+  await updateContentIntegrity([]);
+  await fetchAndRender({ page: 1 });
 };
 
-window.addEventListener('DOMContentLoaded', initApp);
+window.addEventListener('DOMContentLoaded', () => {
+  initApp().catch((error) => {
+    console.error('Gagal menginisialisasi aplikasi', error);
+    updateStatusBanner(elements.statusBanner, {
+      online: true,
+      tone: 'error',
+      message: 'Gagal memulai aplikasi. Muat ulang untuk mencoba lagi.',
+    });
+  });
+});

--- a/public/js/services.newsClient.js
+++ b/public/js/services.newsClient.js
@@ -19,7 +19,13 @@ const cacheKey = (options) => `${options.query || 'default'}::${options.category
 export const createNewsClient = () => {
   const getOfflineFallback = () => readFromStorage(STORAGE_KEYS.cachedArticles, null);
 
-  const persist = (payload) => writeToStorage(STORAGE_KEYS.cachedArticles, { ...payload, persistedAt: new Date().toISOString() });
+  const persist = async (payload) => {
+    try {
+      await writeToStorage(STORAGE_KEYS.cachedArticles, { ...payload, persistedAt: new Date().toISOString() });
+    } catch (error) {
+      console.warn('Gagal menyimpan cache berita terenkripsi', error);
+    }
+  };
 
   const fetchNews = async (options) => {
     const key = cacheKey(options);
@@ -43,7 +49,7 @@ export const createNewsClient = () => {
 
       const payload = await response.json();
       inMemoryCache.set(key, payload);
-      persist({ options, payload });
+      await persist({ options, payload });
       return payload;
     } finally {
       clearTimeout(timeout);

--- a/public/js/services.newsClient.js
+++ b/public/js/services.newsClient.js
@@ -1,0 +1,57 @@
+import { API_BASE_URL, STORAGE_KEYS } from '../constants.js';
+import { readFromStorage, writeToStorage } from '../utils.storage.js';
+
+const inMemoryCache = new Map();
+
+const buildParams = (options) => {
+  const params = new URLSearchParams();
+  params.set('page', options.page?.toString() || '1');
+  params.set('pageSize', options.pageSize?.toString() || '9');
+  if (options.query) params.set('query', options.query);
+  if (options.category) params.set('category', options.category);
+  if (options.sortBy) params.set('sortBy', options.sortBy);
+  if (options.timeRange) params.set('timeRange', options.timeRange);
+  return params;
+};
+
+const cacheKey = (options) => `${options.query || 'default'}::${options.category || 'all'}::${options.sortBy || 'publishedAt'}::${options.timeRange || 'all'}::${options.page || 1}::${options.pageSize || 9}`;
+
+export const createNewsClient = () => {
+  const getOfflineFallback = () => readFromStorage(STORAGE_KEYS.cachedArticles, null);
+
+  const persist = (payload) => writeToStorage(STORAGE_KEYS.cachedArticles, { ...payload, persistedAt: new Date().toISOString() });
+
+  const fetchNews = async (options) => {
+    const key = cacheKey(options);
+    if (inMemoryCache.has(key)) {
+      return { ...inMemoryCache.get(key), cached: true };
+    }
+
+    const params = buildParams(options);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}?${params.toString()}`, {
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error((await response.text()) || 'Gagal memuat berita.');
+      }
+
+      const payload = await response.json();
+      inMemoryCache.set(key, payload);
+      persist({ options, payload });
+      return payload;
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
+  return {
+    fetchNews,
+    getOfflineFallback,
+  };
+};

--- a/public/js/state.filters.js
+++ b/public/js/state.filters.js
@@ -10,12 +10,15 @@ const sanitizeFilter = (filter) => ({
   pageSize: Number(filter.pageSize) || 9,
 });
 
-export const createSavedFiltersStore = () => {
-  let filters = (readFromStorage(STORAGE_KEYS.savedFilters, []) || []).map(sanitizeFilter).filter((filter) => filter.name);
+export const createSavedFiltersStore = async () => {
+  const storedFilters = (await readFromStorage(STORAGE_KEYS.savedFilters, [])) || [];
+  let filters = storedFilters.map(sanitizeFilter).filter((filter) => filter.name);
   const subscribers = new Set();
 
   const commit = () => {
-    writeToStorage(STORAGE_KEYS.savedFilters, filters);
+    writeToStorage(STORAGE_KEYS.savedFilters, filters).catch((error) =>
+      console.warn('Gagal menyimpan filter tersimpan', error),
+    );
     subscribers.forEach((callback) => callback(filters));
   };
 

--- a/public/js/state.filters.js
+++ b/public/js/state.filters.js
@@ -1,0 +1,52 @@
+import { STORAGE_KEYS } from '../constants.js';
+import { readFromStorage, writeToStorage } from '../utils.storage.js';
+
+const sanitizeFilter = (filter) => ({
+  name: String(filter.name || '').trim(),
+  query: filter.query || '',
+  category: filter.category || '',
+  sortBy: filter.sortBy || 'publishedAt',
+  timeRange: filter.timeRange || 'all',
+  pageSize: Number(filter.pageSize) || 9,
+});
+
+export const createSavedFiltersStore = () => {
+  let filters = (readFromStorage(STORAGE_KEYS.savedFilters, []) || []).map(sanitizeFilter).filter((filter) => filter.name);
+  const subscribers = new Set();
+
+  const commit = () => {
+    writeToStorage(STORAGE_KEYS.savedFilters, filters);
+    subscribers.forEach((callback) => callback(filters));
+  };
+
+  return {
+    getAll: () => filters.slice(),
+    subscribe: (callback) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+    add: (filter) => {
+      const sanitized = sanitizeFilter(filter);
+      if (!sanitized.name) return false;
+      const exists = filters.findIndex((item) => item.name.toLowerCase() === sanitized.name.toLowerCase());
+      if (exists >= 0) {
+        filters[exists] = sanitized;
+      } else {
+        filters.push(sanitized);
+      }
+      commit();
+      return true;
+    },
+    remove: (name) => {
+      const before = filters.length;
+      filters = filters.filter((item) => item.name.toLowerCase() !== name.toLowerCase());
+      if (filters.length !== before) {
+        commit();
+      }
+    },
+    clear: () => {
+      filters = [];
+      commit();
+    },
+  };
+};

--- a/public/js/state.preferences.js
+++ b/public/js/state.preferences.js
@@ -1,0 +1,73 @@
+import {
+  CATEGORY_OPTIONS,
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  READING_DENSITY_OPTIONS,
+  SORT_OPTIONS,
+  STORAGE_KEYS,
+  TIME_RANGE_OPTIONS,
+} from '../constants.js';
+import { readFromStorage, writeToStorage } from '../utils.storage.js';
+
+const defaultPreferences = {
+  theme: 'system',
+  viewMode: 'grid',
+  density: READING_DENSITY_OPTIONS[0].value,
+  pageSize: DEFAULT_PAGE_SIZE,
+  sortBy: SORT_OPTIONS[0].value,
+  timeRange: TIME_RANGE_OPTIONS[0].value,
+  category: CATEGORY_OPTIONS[0].value,
+  lastQuery: '',
+};
+
+export const createPreferencesStore = () => {
+  let state = { ...defaultPreferences, ...readFromStorage(STORAGE_KEYS.preferences, {}) };
+  const subscribers = new Set();
+
+  const save = () => writeToStorage(STORAGE_KEYS.preferences, state);
+
+  const setState = (partial) => {
+    state = { ...state, ...partial };
+    save();
+    subscribers.forEach((callback) => callback(state));
+  };
+
+  return {
+    getState: () => state,
+    subscribe: (callback) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+    setTheme: (theme) => setState({ theme }),
+    setViewMode: (viewMode) => {
+      if (!['grid', 'list'].includes(viewMode)) return;
+      setState({ viewMode });
+    },
+    setDensity: (density) => {
+      const allowed = READING_DENSITY_OPTIONS.map((item) => item.value);
+      if (!allowed.includes(density)) return;
+      setState({ density });
+    },
+    setPageSize: (pageSize) => {
+      const parsed = Number(pageSize);
+      if (!PAGE_SIZE_OPTIONS.includes(parsed)) return;
+      setState({ pageSize: parsed });
+    },
+    setSortBy: (sortBy) => {
+      const allowed = SORT_OPTIONS.map((item) => item.value);
+      if (!allowed.includes(sortBy)) return;
+      setState({ sortBy });
+    },
+    setTimeRange: (timeRange) => {
+      const allowed = TIME_RANGE_OPTIONS.map((item) => item.value);
+      if (!allowed.includes(timeRange)) return;
+      setState({ timeRange });
+    },
+    setCategory: (category) => {
+      const allowed = CATEGORY_OPTIONS.map((item) => item.value);
+      if (!allowed.includes(category)) return;
+      setState({ category });
+    },
+    setLastQuery: (lastQuery) => setState({ lastQuery }),
+  };
+};

--- a/public/js/state.preferences.js
+++ b/public/js/state.preferences.js
@@ -20,11 +20,15 @@ const defaultPreferences = {
   lastQuery: '',
 };
 
-export const createPreferencesStore = () => {
-  let state = { ...defaultPreferences, ...readFromStorage(STORAGE_KEYS.preferences, {}) };
+export const createPreferencesStore = async () => {
+  const persistedPreferences = (await readFromStorage(STORAGE_KEYS.preferences, {})) || {};
+  let state = { ...defaultPreferences, ...persistedPreferences };
   const subscribers = new Set();
 
-  const save = () => writeToStorage(STORAGE_KEYS.preferences, state);
+  const save = () =>
+    writeToStorage(STORAGE_KEYS.preferences, state).catch((error) =>
+      console.warn('Gagal menyimpan preferensi', error),
+    );
 
   const setState = (partial) => {
     state = { ...state, ...partial };

--- a/public/js/ui.renderers.js
+++ b/public/js/ui.renderers.js
@@ -1,4 +1,4 @@
-import { NICHE_FOCUS_AREAS, TRENDING_IDEAS } from '../constants.js';
+import { NICHE_FOCUS_AREAS, SECURITY_MEASURES, TRENDING_IDEAS } from '../constants.js';
 import { animateSwap, createFragmentFromHTML, qsa, sanitizeUrl, setHidden, toggleClass, truncateText } from '../utils.dom.js';
 import { buildMetaText, formatDateTime, pluralize } from '../utils.formatters.js';
 
@@ -196,6 +196,27 @@ export const renderNicheFocus = (container, onSelect) => {
     `);
     const button = element.querySelector('button');
     button?.addEventListener('click', () => onSelect?.(area));
+    fragment.appendChild(element);
+  });
+  container.innerHTML = '';
+  container.appendChild(fragment);
+};
+
+export const renderSecurityHighlights = (container) => {
+  if (!container) return;
+  const fragment = document.createDocumentFragment();
+  SECURITY_MEASURES.forEach((item) => {
+    const element = createFragmentFromHTML(`
+      <article class="flex items-start gap-3 rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/90 dark:bg-gray-900/60 p-4 shadow-sm">
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-500/20 text-blue-600 dark:text-blue-300">
+          <i class="${item.icon}"></i>
+        </span>
+        <div class="space-y-1">
+          <h4 class="text-sm font-semibold">${item.title}</h4>
+          <p class="text-xs text-gray-600 dark:text-gray-300 leading-relaxed">${item.description}</p>
+        </div>
+      </article>
+    `);
     fragment.appendChild(element);
   });
   container.innerHTML = '';

--- a/public/js/ui.renderers.js
+++ b/public/js/ui.renderers.js
@@ -1,0 +1,276 @@
+import { NICHE_FOCUS_AREAS, TRENDING_IDEAS } from '../constants.js';
+import { animateSwap, createFragmentFromHTML, qsa, sanitizeUrl, setHidden, toggleClass, truncateText } from '../utils.dom.js';
+import { buildMetaText, formatDateTime, pluralize } from '../utils.formatters.js';
+
+const defaultImage = 'https://placehold.co/800x600/png?text=Gambar+Berita+Tidak+Tersedia';
+
+export const renderSkeletons = ({ container, viewMode = 'grid', count = 9, density = 'comfortable' }) => {
+  if (!container) return;
+  const gapClass =
+    viewMode === 'list'
+      ? density === 'compact'
+        ? 'space-y-4'
+        : 'space-y-6'
+      : density === 'compact'
+      ? 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4'
+      : 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6';
+  container.className = gapClass;
+  const fragment = document.createDocumentFragment();
+  for (let index = 0; index < count; index += 1) {
+    const card = createFragmentFromHTML(`
+      <article class="rounded-2xl border border-gray-200 dark:border-gray-800 overflow-hidden animate-pulse bg-white/60 dark:bg-gray-900/60">
+        <div class="h-44 bg-gray-200 dark:bg-gray-800"></div>
+        <div class="${density === 'compact' ? 'p-5 space-y-3' : 'p-6 space-y-4'}">
+          <div class="h-4 bg-gray-200 dark:bg-gray-800 rounded w-2/3"></div>
+          <div class="h-4 bg-gray-200 dark:bg-gray-800 rounded w-1/2"></div>
+          <div class="space-y-2">
+            <div class="h-3 bg-gray-200 dark:bg-gray-800 rounded"></div>
+            <div class="h-3 bg-gray-200 dark:bg-gray-800 rounded"></div>
+            <div class="h-3 bg-gray-200 dark:bg-gray-800 rounded w-2/3"></div>
+          </div>
+        </div>
+      </article>
+    `);
+    fragment.appendChild(card);
+  }
+  container.innerHTML = '';
+  container.appendChild(fragment);
+};
+
+export const renderArticles = ({ container, articles, viewMode, density = 'comfortable' }) => {
+  if (!container) return;
+  const layoutClass =
+    viewMode === 'list'
+      ? density === 'compact'
+        ? 'space-y-4'
+        : 'space-y-6'
+      : density === 'compact'
+      ? 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4'
+      : 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6';
+  container.className = layoutClass;
+  if (!articles?.length) {
+    container.innerHTML = '';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  articles.forEach((article) => {
+    const meta = buildMetaText(article);
+    const card = createFragmentFromHTML(`
+      <article class="relative group rounded-2xl border border-gray-200 dark:border-gray-800 overflow-hidden bg-white dark:bg-gray-900 shadow-sm hover:shadow-lg transition" data-density="${density}">
+        <div class="relative h-48 overflow-hidden">
+          <img src="${article.image || defaultImage}" alt="${article.title ? article.title.replace(/"/g, '') : 'Gambar artikel'}" class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy"/>
+          <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"></div>
+          <div class="absolute bottom-3 left-3 right-3 flex items-center justify-between text-white text-xs">
+            <span class="inline-flex items-center gap-2 bg-black/40 backdrop-blur px-3 py-1 rounded-full">
+              <i class="fas fa-newspaper"></i>
+              ${article.source?.name || 'Sumber tidak diketahui'}
+            </span>
+            <time datetime="${article.publishedAt}">${meta}</time>
+          </div>
+        </div>
+        <div class="${density === 'compact' ? 'p-5 space-y-3' : 'p-6 space-y-4'}">
+          <div class="space-y-2">
+            <h3 class="text-lg font-semibold leading-tight">
+              <a href="${sanitizeUrl(article.url)}" target="_blank" rel="noopener" class="hover:text-blue-600 dark:hover:text-blue-400 transition">
+                ${article.title || 'Tanpa judul'}
+              </a>
+            </h3>
+            <p class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">${truncateText(article.description || 'Tidak ada ringkasan tersedia.')}</p>
+          </div>
+          <div class="flex flex-wrap items-center ${density === 'compact' ? 'gap-2' : 'gap-3'} text-xs text-gray-500 dark:text-gray-400">
+            <span class="inline-flex items-center gap-1"><i class="fas fa-clock"></i>${meta}</span>
+            <button class="share-button inline-flex items-center gap-2 px-3 py-1 rounded-full border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition" data-url="${sanitizeUrl(article.url)}" data-title="${article.title || ''}">
+              <i class="fas fa-share-alt"></i> Bagikan
+            </button>
+            <a href="${sanitizeUrl(article.url)}" target="_blank" rel="noopener" class="ml-auto inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-medium">
+              Baca selengkapnya <i class="fas fa-arrow-right"></i>
+            </a>
+          </div>
+        </div>
+      </article>
+    `);
+    fragment.appendChild(card);
+  });
+
+  container.innerHTML = '';
+  container.appendChild(fragment);
+  animateSwap(container);
+};
+
+export const renderFeaturedArticle = (container, article) => {
+  if (!container) return;
+  if (!article) {
+    container.innerHTML = '';
+    container.classList.add('hidden');
+    return;
+  }
+
+  container.classList.remove('hidden');
+  container.innerHTML = '';
+  const card = createFragmentFromHTML(`
+    <div class="grid md:grid-cols-2">
+      <div class="relative h-72 md:h-full overflow-hidden rounded-l-2xl">
+        <img src="${article.image || defaultImage}" alt="${article.title ? article.title.replace(/"/g, '') : 'Gambar sorotan'}" class="w-full h-full object-cover" loading="lazy" />
+        <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"></div>
+        <div class="absolute bottom-0 left-0 right-0 p-4 text-white space-y-2">
+          <span class="inline-flex items-center gap-2 text-xs uppercase tracking-wider">
+            <i class="fas fa-star text-yellow-400"></i> Sorotan pilihan
+          </span>
+          <time datetime="${article.publishedAt}" class="text-sm text-white/80">${buildMetaText(article)}</time>
+        </div>
+      </div>
+      <div class="p-8 space-y-5">
+        <h3 class="text-2xl font-bold leading-tight">${article.title || 'Sorotan utama NewsApp'}</h3>
+        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">${truncateText(
+          article.description || 'Analisis mendalam dan rangkuman isu utama hari ini.',
+          320,
+        )}</p>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+          <span class="inline-flex items-center gap-2"><i class="fas fa-building"></i>${article.source?.name || 'Sumber tidak diketahui'}</span>
+          <span class="inline-flex items-center gap-2"><i class="fas fa-clock"></i>${buildMetaText(article)}</span>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <a href="${sanitizeUrl(article.url)}" target="_blank" rel="noopener" class="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-5 py-3 rounded-lg transition">
+            Baca sorotan <i class="fas fa-arrow-right"></i>
+          </a>
+          <button class="share-button inline-flex items-center gap-2 border border-gray-200 dark:border-gray-700 px-5 py-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition" data-url="${sanitizeUrl(article.url)}" data-title="${article.title || ''}">
+            <i class="fas fa-share-alt"></i> Bagikan
+          </button>
+        </div>
+      </div>
+    </div>
+  `);
+
+  container.appendChild(card);
+  animateSwap(container);
+};
+
+export const renderStats = ({
+  totalArticlesStat,
+  activeFiltersStat,
+  lastUpdatedStat,
+  total,
+  activeFilters,
+  lastUpdated,
+}) => {
+  if (totalArticlesStat) totalArticlesStat.textContent = `${total.toLocaleString('id-ID')} ${pluralize(total, 'artikel', 'artikel')}`;
+  if (activeFiltersStat) activeFiltersStat.textContent = activeFilters;
+  if (lastUpdatedStat) lastUpdatedStat.textContent = lastUpdated ? formatDateTime(lastUpdated) : '-';
+};
+
+export const renderTrendingTopics = (container, onSelect) => {
+  if (!container) return;
+  const ideas = TRENDING_IDEAS.slice().sort(() => Math.random() - 0.5).slice(0, 6);
+  const fragment = document.createDocumentFragment();
+  ideas.forEach((idea) => {
+    const element = createFragmentFromHTML(`
+      <button type="button" class="flex flex-col items-start gap-2 p-5 rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 hover:border-blue-500 hover:shadow-md transition text-left" data-query="${idea.query}">
+        <span class="inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-400"><i class="${idea.icon}"></i>${idea.title}</span>
+        <span class="text-sm text-gray-600 dark:text-gray-300">${idea.description}</span>
+      </button>
+    `);
+    const button = element.querySelector('button');
+    button?.addEventListener('click', () => onSelect?.(idea));
+    fragment.appendChild(element);
+  });
+  container.innerHTML = '';
+  container.appendChild(fragment);
+};
+
+export const renderNicheFocus = (container, onSelect) => {
+  if (!container) return;
+  const fragment = document.createDocumentFragment();
+  NICHE_FOCUS_AREAS.forEach((area) => {
+    const element = createFragmentFromHTML(`
+      <article class="flex flex-col gap-3 rounded-2xl border border-gray-200 dark:border-gray-800 bg-gradient-to-br from-white via-white to-blue-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 p-6">
+        <div class="flex items-center gap-3 text-blue-600 dark:text-blue-400">
+          <i class="${area.icon} text-xl"></i>
+          <h4 class="text-lg font-semibold">${area.title}</h4>
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">${area.description}</p>
+        <button type="button" class="mt-auto inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline focus:outline-none" data-query="${area.query}">
+          Telusuri topik <i class="fas fa-arrow-right"></i>
+        </button>
+      </article>
+    `);
+    const button = element.querySelector('button');
+    button?.addEventListener('click', () => onSelect?.(area));
+    fragment.appendChild(element);
+  });
+  container.innerHTML = '';
+  container.appendChild(fragment);
+};
+
+export const renderSavedFilters = (container, filters, { onSelect, onDelete }) => {
+  if (!container) return;
+  container.innerHTML = '';
+  if (!filters?.length) {
+    container.innerHTML = '<p class="text-sm text-gray-500 dark:text-gray-400">Belum ada filter tersimpan.</p>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  filters.forEach((filter) => {
+    const element = createFragmentFromHTML(`
+      <li class="flex items-center gap-3 justify-between px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+        <div class="flex flex-col">
+          <span class="font-medium">${filter.name}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">${filter.query || 'Semua berita'} • ${filter.category || 'Semua kategori'} • ${filter.sortBy}</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <button type="button" class="inline-flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:underline focus:outline-none" data-action="apply">Gunakan</button>
+          <button type="button" class="inline-flex items-center gap-2 text-sm text-red-500 hover:underline focus:outline-none" data-action="delete"><i class="fas fa-trash"></i></button>
+        </div>
+      </li>
+    `);
+    fragment.appendChild(element);
+  });
+
+  qsa('li', fragment).forEach((item, index) => {
+    const filter = filters[index];
+    item.querySelector('[data-action="apply"]').addEventListener('click', () => onSelect?.(filter));
+    item.querySelector('[data-action="delete"]').addEventListener('click', () => onDelete?.(filter));
+  });
+
+  container.appendChild(fragment);
+};
+
+export const updateViewToggle = (viewToggle, viewMode) => {
+  if (!viewToggle) return;
+  qsa('button[data-view]', viewToggle).forEach((button) => {
+    const isActive = button.dataset.view === viewMode;
+    toggleClass(button, 'bg-blue-600', isActive);
+    toggleClass(button, 'text-white', isActive);
+    toggleClass(button, 'bg-gray-100', !isActive);
+    toggleClass(button, 'dark:bg-gray-800', !isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+};
+
+export const updateStatusBanner = (banner, { online, message, tone }) => {
+  if (!banner) return;
+  banner.textContent = message;
+  banner.className = `fixed top-20 inset-x-0 mx-auto max-w-md rounded-full px-4 py-2 text-sm font-medium shadow-lg transition ${
+    tone === 'error'
+      ? 'bg-red-100 text-red-700 dark:bg-red-900/70 dark:text-red-100'
+      : tone === 'success'
+      ? 'bg-green-100 text-green-700 dark:bg-green-900/70 dark:text-green-100'
+      : 'bg-blue-100 text-blue-700 dark:bg-blue-900/70 dark:text-blue-100'
+  }`;
+  setHidden(banner, online === null);
+};
+
+export const updateDensityToggle = (toggle, density) => {
+  if (!toggle) return;
+  const icon = toggle.querySelector('i');
+  const label = toggle.querySelector('.density-label');
+  const isCompact = density === 'compact';
+  if (icon) icon.className = isCompact ? 'fas fa-grip-lines' : 'fas fa-layer-group';
+  if (label) label.textContent = isCompact ? 'Mode padat' : 'Ruang lega';
+  const nextAction = isCompact ? 'Longgarkan jarak antar kartu' : 'Rapatkan jarak antar kartu';
+  toggle.dataset.density = density;
+  toggle.setAttribute('aria-pressed', String(isCompact));
+  toggle.setAttribute('aria-label', nextAction);
+  toggle.setAttribute('title', nextAction);
+};

--- a/public/js/utils.dom.js
+++ b/public/js/utils.dom.js
@@ -1,0 +1,51 @@
+export const qs = (selector, scope = document) => scope.querySelector(selector);
+
+export const qsa = (selector, scope = document) => Array.from(scope.querySelectorAll(selector));
+
+export const setHidden = (element, hidden) => {
+  if (!element) return;
+  element.hidden = hidden;
+  element.classList.toggle('hidden', hidden);
+};
+
+export const toggleClass = (element, className, condition) => {
+  if (!element) return;
+  element.classList.toggle(className, Boolean(condition));
+};
+
+export const createFragmentFromHTML = (html) => {
+  const template = document.createElement('template');
+  template.innerHTML = html.trim();
+  return template.content;
+};
+
+export const sanitizeUrl = (url) => {
+  try {
+    const parsed = new URL(url);
+    return parsed.href;
+  } catch (error) {
+    return '#';
+  }
+};
+
+export const truncateText = (text, maxLength = 160) => {
+  if (!text) return '';
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength).trim()}…`;
+};
+
+export const preferReducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+export const animateSwap = (container) => {
+  if (!container || preferReducedMotion()) return;
+  container.animate(
+    [
+      { opacity: 0, transform: 'translateY(12px)' },
+      { opacity: 1, transform: 'translateY(0)' },
+    ],
+    {
+      duration: 320,
+      easing: 'ease-out',
+    },
+  );
+};

--- a/public/js/utils.formatters.js
+++ b/public/js/utils.formatters.js
@@ -1,0 +1,38 @@
+export const formatDate = (dateString) => {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString('id-ID', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+};
+
+export const formatDateTime = (value) => {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString('id-ID', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+};
+
+export const buildMetaText = (article) => {
+  if (!article) return '';
+  const parts = [];
+  const formattedDate = formatDate(article.publishedAt);
+  if (formattedDate) {
+    parts.push(formattedDate);
+  }
+  if (article.source?.name) {
+    parts.push(article.source.name);
+  }
+  return parts.join(' • ');
+};
+
+export const pluralize = (value, singular, plural) => {
+  const amount = Number(value) || 0;
+  return amount === 1 ? singular : plural;
+};

--- a/public/js/utils.security.js
+++ b/public/js/utils.security.js
@@ -1,0 +1,138 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const STORAGE_SALT = 'newsapp::secure::preferences';
+const KEY_SALT = 'newsapp::secure::key';
+const PBKDF2_ITERATIONS = 120000;
+
+const bufferToHex = (buffer) =>
+  Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+const bufferToBase64 = (buffer) => {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+};
+
+const encodeBase64String = (value) => bufferToBase64(encoder.encode(value).buffer);
+const decodeBase64String = (value) => decoder.decode(base64ToBuffer(value));
+
+const base64ToBuffer = (value) => {
+  const binary = atob(value);
+  const length = binary.length;
+  const bytes = new Uint8Array(length);
+  for (let index = 0; index < length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+};
+
+export const isSecureStorageSupported = () =>
+  typeof window !== 'undefined' && Boolean(window.isSecureContext) && Boolean(window.crypto?.subtle);
+
+const getKeyMaterial = async () => {
+  if (!isSecureStorageSupported()) return null;
+  const secretSeed = `${window.location.origin}::${navigator.userAgent}::${STORAGE_SALT}`;
+  return window.crypto.subtle.importKey('raw', encoder.encode(secretSeed), 'PBKDF2', false, ['deriveKey']);
+};
+
+const deriveAesKey = async () => {
+  if (!isSecureStorageSupported()) return null;
+  const material = await getKeyMaterial();
+  if (!material) return null;
+  return window.crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: encoder.encode(KEY_SALT),
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    material,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+};
+
+export const hashKey = async (key) => {
+  if (!isSecureStorageSupported()) return key;
+  const digest = await window.crypto.subtle.digest('SHA-256', encoder.encode(`${key}::${KEY_SALT}`));
+  return bufferToHex(digest);
+};
+
+export const encryptValue = async (value) => {
+  try {
+    const key = await deriveAesKey();
+    if (!key) {
+      return encodeBase64String(value);
+    }
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoder.encode(value));
+    return `${bufferToBase64(iv.buffer)}.${bufferToBase64(encrypted)}`;
+  } catch (error) {
+    console.warn('Gagal mengenkripsi data, fallback ke encoding dasar', error);
+    try {
+      return encodeBase64String(value);
+    } catch (fallbackError) {
+      console.warn('Fallback encoding gagal', fallbackError);
+      return value;
+    }
+  }
+};
+
+export const decryptValue = async (payload) => {
+  if (!payload) return null;
+  try {
+    const key = await deriveAesKey();
+    if (!key) {
+      return decodeBase64String(payload);
+    }
+    const [rawIv, rawCipher] = payload.split('.');
+    if (!rawIv || !rawCipher) return null;
+    const iv = new Uint8Array(base64ToBuffer(rawIv));
+    const ciphertext = base64ToBuffer(rawCipher);
+    const decrypted = await window.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    return decoder.decode(decrypted);
+  } catch (error) {
+    try {
+      return decodeBase64String(payload);
+    } catch (fallbackError) {
+      console.warn('Gagal mendekripsi data terenkripsi', error, fallbackError);
+      return null;
+    }
+  }
+};
+
+export const generateIntegrityHash = async (input) => {
+  const normalized =
+    typeof input === 'string'
+      ? input
+      : JSON.stringify(input, Object.keys(input || {}).sort());
+  try {
+    if (isSecureStorageSupported()) {
+      const digest = await window.crypto.subtle.digest('SHA-256', encoder.encode(`${normalized}::${STORAGE_SALT}`));
+      return bufferToHex(digest).toUpperCase();
+    }
+  } catch (error) {
+    console.warn('Gagal menghasilkan hash SHA-256, gunakan fallback', error);
+  }
+  try {
+    return encodeBase64String(normalized).toUpperCase();
+  } catch {
+    return `${normalized}`.toUpperCase();
+  }
+};
+
+export const maskFingerprint = (fingerprint) => {
+  if (!fingerprint) return 'Belum tersedia';
+  if (fingerprint.length <= 12) return fingerprint;
+  const start = fingerprint.slice(0, 8);
+  const end = fingerprint.slice(-8);
+  return `${start} ••• ${end}`;
+};
+

--- a/public/js/utils.storage.js
+++ b/public/js/utils.storage.js
@@ -1,0 +1,26 @@
+export const readFromStorage = (key, fallback) => {
+  try {
+    const value = localStorage.getItem(key);
+    if (!value) return fallback;
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn('Gagal membaca dari storage', error);
+    return fallback;
+  }
+};
+
+export const writeToStorage = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Gagal menulis ke storage', error);
+  }
+};
+
+export const removeFromStorage = (key) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.warn('Gagal menghapus dari storage', error);
+  }
+};

--- a/public/js/utils.storage.js
+++ b/public/js/utils.storage.js
@@ -1,25 +1,53 @@
-export const readFromStorage = (key, fallback) => {
+import { decryptValue, encryptValue, hashKey } from './utils.security.js';
+
+const readLegacyValue = (key) => {
+  const legacyValue = localStorage.getItem(key);
+  if (!legacyValue) return undefined;
   try {
-    const value = localStorage.getItem(key);
-    if (!value) return fallback;
-    return JSON.parse(value);
+    return JSON.parse(legacyValue);
+  } catch (error) {
+    console.warn('Gagal mengurai data legacy dari storage', error);
+    return undefined;
+  }
+};
+
+export const readFromStorage = async (key, fallback) => {
+  try {
+    const secureKey = await hashKey(key);
+    const storedValue = localStorage.getItem(secureKey);
+    if (!storedValue) {
+      const legacy = readLegacyValue(key);
+      return legacy === undefined ? fallback : legacy;
+    }
+    const decrypted = await decryptValue(storedValue);
+    if (!decrypted) return fallback;
+    return JSON.parse(decrypted);
   } catch (error) {
     console.warn('Gagal membaca dari storage', error);
     return fallback;
   }
 };
 
-export const writeToStorage = (key, value) => {
+export const writeToStorage = async (key, value) => {
   try {
-    localStorage.setItem(key, JSON.stringify(value));
+    const secureKey = await hashKey(key);
+    const payload = await encryptValue(JSON.stringify(value));
+    localStorage.setItem(secureKey, payload);
+    if (secureKey !== key && localStorage.getItem(key)) {
+      localStorage.removeItem(key);
+    }
   } catch (error) {
     console.warn('Gagal menulis ke storage', error);
   }
 };
 
-export const removeFromStorage = (key) => {
+export const removeFromStorage = async (key) => {
   try {
-    localStorage.removeItem(key);
+    const secureKey = await hashKey(key);
+    localStorage.removeItem(secureKey);
+    if (secureKey !== key) {
+      localStorage.removeItem(key);
+    }
   } catch (error) {
     console.warn('Gagal menghapus dari storage', error);
   }

--- a/src/routes/news.ts
+++ b/src/routes/news.ts
@@ -11,6 +11,8 @@ router.get(
   asyncHandler(async (req, res) => {
     const queryParam = typeof req.query.query === 'string' ? req.query.query : '';
     const categoryParam = typeof req.query.category === 'string' ? req.query.category : '';
+    const sortByParam = typeof req.query.sortBy === 'string' ? req.query.sortBy : '';
+    const timeRangeParam = typeof req.query.timeRange === 'string' ? req.query.timeRange : '';
 
     const pageParam = Array.isArray(req.query.page) ? req.query.page[0] : req.query.page;
     const pageSizeParam = Array.isArray(req.query.pageSize) ? req.query.pageSize[0] : req.query.pageSize;
@@ -31,12 +33,16 @@ router.get(
       category: categoryParam,
       page,
       pageSize,
+      sortBy: sortByParam,
+      timeRange: timeRangeParam,
     });
 
     res.json({
       totalArticles: result.totalArticles,
       articles: result.articles,
       cached: result.cached,
+      sortBy: result.sortBy,
+      timeRange: result.timeRange,
       page,
       pageSize,
     });

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -3,11 +3,17 @@ import createHttpError from 'http-errors';
 import NodeCache from 'node-cache';
 import { appConfig } from '../config/env';
 
+type SortBy = 'publishedAt' | 'relevance' | 'popularity';
+
+type TimeRange = '24h' | '48h' | '7d' | '30d' | 'all';
+
 type NewsQuery = {
   query: string;
   category?: string;
   page: number;
   pageSize: number;
+  sortBy?: SortBy | string;
+  timeRange?: TimeRange | string;
 };
 
 type GNewsArticle = {
@@ -31,6 +37,8 @@ const topicMap: Record<string, string> = {
   technology: 'technology',
   sports: 'sports',
   health: 'health',
+  entertainment: 'entertainment',
+  science: 'science',
 };
 
 const cache = new NodeCache({
@@ -43,18 +51,43 @@ export type NewsResult = {
   totalArticles: number;
   articles: GNewsArticle[];
   cached: boolean;
+  sortBy: SortBy;
+  timeRange: TimeRange;
 };
 
-const buildCacheKey = ({ query, category, page, pageSize }: NewsQuery): string =>
-  [query || 'default', category || 'all', page, pageSize].join('::');
+const buildCacheKey = ({ query, category, page, pageSize, sortBy, timeRange }: NewsQuery): string =>
+  [query || 'default', category || 'all', page, pageSize, sortBy || 'publishedAt', timeRange || 'all'].join('::');
+
+const sortByValues: SortBy[] = ['publishedAt', 'relevance', 'popularity'];
+const timeRangeMap: Record<Exclude<TimeRange, 'all'>, number> = {
+  '24h': 24,
+  '48h': 48,
+  '7d': 24 * 7,
+  '30d': 24 * 30,
+};
 
 export async function fetchNews(query: NewsQuery): Promise<NewsResult> {
   const sanitizedQuery = query.query.trim() || 'berita';
   const sanitizedCategory = query.category?.trim().toLowerCase();
   const page = Number.isFinite(query.page) && query.page > 0 ? query.page : 1;
   const pageSize = Number.isFinite(query.pageSize) && query.pageSize > 0 ? query.pageSize : appConfig.defaultPageSize;
+  const providedSortBy = (query.sortBy ?? '').toString().toLowerCase();
+  const sanitizedSortBy = sortByValues.includes(providedSortBy as SortBy)
+    ? (providedSortBy as SortBy)
+    : 'publishedAt';
+  const providedTimeRange = (query.timeRange ?? '').toString().toLowerCase();
+  const sanitizedTimeRange = (['24h', '48h', '7d', '30d'].includes(providedTimeRange)
+    ? (providedTimeRange as TimeRange)
+    : 'all') as TimeRange;
 
-  const cacheKey = buildCacheKey({ query: sanitizedQuery, category: sanitizedCategory, page, pageSize });
+  const cacheKey = buildCacheKey({
+    query: sanitizedQuery,
+    category: sanitizedCategory,
+    page,
+    pageSize,
+    sortBy: sanitizedSortBy,
+    timeRange: sanitizedTimeRange,
+  });
   const cached = cache.get<NewsResult>(cacheKey);
   if (cached) {
     return { ...cached, cached: true };
@@ -76,12 +109,28 @@ export async function fetchNews(query: NewsQuery): Promise<NewsResult> {
     params.topic = topicMap[sanitizedCategory];
   }
 
+  if (sanitizedSortBy) {
+    params.sortby = sanitizedSortBy;
+  }
+
+  if (sanitizedTimeRange !== 'all') {
+    const hours = timeRangeMap[sanitizedTimeRange as Exclude<TimeRange, 'all'>];
+    if (hours) {
+      const to = new Date();
+      const from = new Date(to.getTime() - hours * 60 * 60 * 1000);
+      params.from = from.toISOString();
+      params.to = to.toISOString();
+    }
+  }
+
   try {
     const response = await axios.get<GNewsResponse>(`${appConfig.gnews.baseUrl}/search`, { params, timeout: 7000 });
     const payload: NewsResult = {
       totalArticles: response.data.totalArticles ?? response.data.articles.length,
       articles: response.data.articles,
       cached: false,
+      sortBy: sanitizedSortBy,
+      timeRange: sanitizedTimeRange,
     };
     cache.set(cacheKey, payload);
     return payload;


### PR DESCRIPTION
## Summary
- add a keyboard-driven command palette with dedicated header/mobile triggers, scroll progress, and a back-to-top shortcut for easier navigation
- introduce reading density and manual refresh controls backed by persisted preferences and updated renderers for skeletons/articles
- expand trending topic tiles and saved-filter tips while wiring constants, stores, and UI wiring for richer personalization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7c99634088327aff8e90355d186fc