### PR TITLE
Fix frontend module imports and fetch revalidation

### DIFF
--- a/public/js/services.newsClient.js
+++ b/public/js/services.newsClient.js
@@ -1,5 +1,5 @@
-import { API_BASE_URL, STORAGE_KEYS } from '../constants.js';
-import { readFromStorage, writeToStorage } from '../utils.storage.js';
+import { API_BASE_URL, STORAGE_KEYS } from './constants.js';
+import { readFromStorage, writeToStorage } from './utils.storage.js';
 
 const inMemoryCache = new Map();
 
@@ -23,13 +23,11 @@ export const createNewsClient = () => {
 
   const fetchNews = async (options) => {
     const key = cacheKey(options);
-    if (inMemoryCache.has(key)) {
-      return { ...inMemoryCache.get(key), cached: true };
-    }
-
     const params = buildParams(options);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 8000);
+
+    const cached = inMemoryCache.get(key);
 
     try {
       const response = await fetch(`${API_BASE_URL}?${params.toString()}`, {
@@ -45,6 +43,11 @@ export const createNewsClient = () => {
       inMemoryCache.set(key, payload);
       persist({ options, payload });
       return payload;
+    } catch (error) {
+      if (cached) {
+        return { ...cached, cached: true };
+      }
+      throw error;
     } finally {
       clearTimeout(timeout);
     }

--- a/public/js/state.filters.js
+++ b/public/js/state.filters.js
@@ -1,5 +1,5 @@
-import { STORAGE_KEYS } from '../constants.js';
-import { readFromStorage, writeToStorage } from '../utils.storage.js';
+import { STORAGE_KEYS } from './constants.js';
+import { readFromStorage, writeToStorage } from './utils.storage.js';
 
 const sanitizeFilter = (filter) => ({
   name: String(filter.name || '').trim(),

--- a/public/js/state.preferences.js
+++ b/public/js/state.preferences.js
@@ -1,5 +1,5 @@
-import { CATEGORY_OPTIONS, DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS, SORT_OPTIONS, STORAGE_KEYS, TIME_RANGE_OPTIONS } from '../constants.js';
-import { readFromStorage, writeToStorage } from '../utils.storage.js';
+import { CATEGORY_OPTIONS, DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS, SORT_OPTIONS, STORAGE_KEYS, TIME_RANGE_OPTIONS } from './constants.js';
+import { readFromStorage, writeToStorage } from './utils.storage.js';
 
 const defaultPreferences = {
   theme: 'system',

--- a/public/js/ui.renderers.js
+++ b/public/js/ui.renderers.js
@@ -1,6 +1,6 @@
-import { NICHE_FOCUS_AREAS, TRENDING_IDEAS } from '../constants.js';
-import { animateSwap, createFragmentFromHTML, qsa, sanitizeUrl, setHidden, toggleClass, truncateText } from '../utils.dom.js';
-import { buildMetaText, formatDateTime, pluralize } from '../utils.formatters.js';
+import { NICHE_FOCUS_AREAS, TRENDING_IDEAS } from './constants.js';
+import { animateSwap, createFragmentFromHTML, qsa, sanitizeUrl, setHidden, toggleClass, truncateText } from './utils.dom.js';
+import { buildMetaText, formatDateTime, pluralize } from './utils.formatters.js';
 
 const defaultImage = 'https://placehold.co/800x600/png?text=Gambar+Berita+Tidak+Tersedia';
 


### PR DESCRIPTION
## Summary
- fix the ES module import paths for frontend state and renderer utilities so the browser can load them directly
- rework the news client cache to always revalidate with the API while still falling back to cached data when offline

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8b3abd9948327890c3994c6e829c8