### PR TITLE
Add backend tests for news service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/http-errors": "^2.0.5",
         "@types/morgan": "^1.9.10",
         "@types/node": "^18.19.127",
+        "axios-mock-adapter": "^1.22.0",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.2"
@@ -363,6 +364,20 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
+      "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1003,6 +1018,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1320,6 +1342,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-core-module": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "test:debug": "PWDEBUG=1 playwright test",
+    "test:backend": "npm run build && node --test tests/backend",
     "pretest": "npm run build"
   },
   "keywords": [
@@ -45,6 +46,7 @@
     "@types/http-errors": "^2.0.5",
     "@types/morgan": "^1.9.10",
     "@types/node": "^18.19.127",
+    "axios-mock-adapter": "^1.22.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.2"

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -146,3 +146,7 @@ export async function fetchNews(query: NewsQuery): Promise<NewsResult> {
     throw createHttpError(500, 'Terjadi kesalahan tidak terduga saat mengambil berita.');
   }
 }
+
+export function clearNewsCache(): void {
+  cache.flushAll();
+}

--- a/tests/backend/newsService.test.js
+++ b/tests/backend/newsService.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+process.env.GNEWS_API_KEY = process.env.GNEWS_API_KEY || 'unit-test-key';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const axios = require('axios');
+const MockAdapter = require('axios-mock-adapter');
+
+const { fetchNews, clearNewsCache } = require('../../dist/services/newsService');
+const { appConfig } = require('../../dist/config/env');
+
+describe('fetchNews', () => {
+  let mock;
+  const sampleResponse = {
+    totalArticles: 2,
+    articles: [
+      {
+        title: 'Berita Teknologi 1',
+        description: 'Deskripsi berita 1',
+        url: 'https://example.com/1',
+        image: 'https://example.com/1.png',
+        publishedAt: new Date().toISOString(),
+        source: { name: 'Example Source' },
+      },
+      {
+        title: 'Berita Teknologi 2',
+        description: 'Deskripsi berita 2',
+        url: 'https://example.com/2',
+        image: 'https://example.com/2.png',
+        publishedAt: new Date().toISOString(),
+        source: { name: 'Example Source' },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+    clearNewsCache();
+    appConfig.gnews.apiKey = 'unit-test-key';
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('sanitizes query parameters and returns uncached response', async () => {
+    mock.onGet(`${appConfig.gnews.baseUrl}/search`).reply((config) => {
+      assert.equal(config.params.q, 'berita');
+      assert.equal(config.params.topic, 'technology');
+      assert.equal(config.params.page, 1);
+      assert.equal(config.params.max, appConfig.defaultPageSize);
+      assert.equal(config.params.sortby, 'publishedAt');
+      assert.ok(!('from' in config.params));
+      assert.ok(!('to' in config.params));
+      return [200, sampleResponse];
+    });
+
+    const result = await fetchNews({
+      query: '   ',
+      category: ' Technology ',
+      page: -5,
+      pageSize: 0,
+      sortBy: 'unknown',
+      timeRange: 'invalid',
+    });
+
+    assert.equal(result.totalArticles, sampleResponse.totalArticles);
+    assert.deepEqual(result.articles, sampleResponse.articles);
+    assert.equal(result.cached, false);
+    assert.equal(result.sortBy, 'publishedAt');
+    assert.equal(result.timeRange, 'all');
+  });
+
+  it('returns cached response on subsequent calls', async () => {
+    let requestCount = 0;
+    mock.onGet(`${appConfig.gnews.baseUrl}/search`).reply(() => {
+      requestCount += 1;
+      return [200, sampleResponse];
+    });
+
+    const first = await fetchNews({
+      query: 'Teknologi',
+      category: 'technology',
+      page: 2,
+      pageSize: 5,
+      sortBy: 'relevance',
+      timeRange: 'all',
+    });
+
+    assert.equal(first.cached, false);
+    assert.equal(requestCount, 1);
+
+    const second = await fetchNews({
+      query: 'Teknologi',
+      category: 'technology',
+      page: 2,
+      pageSize: 5,
+      sortBy: 'relevance',
+      timeRange: 'all',
+    });
+
+    assert.equal(second.cached, true);
+    assert.equal(requestCount, 1);
+  });
+
+  it('applies time range filters when provided', async () => {
+    mock.onGet(`${appConfig.gnews.baseUrl}/search`).reply((config) => {
+      assert.equal(config.params.sortby, 'publishedAt');
+      assert.equal(config.params.q, 'Olahraga');
+      assert.ok(typeof config.params.from === 'string');
+      assert.ok(typeof config.params.to === 'string');
+      const from = Date.parse(config.params.from);
+      const to = Date.parse(config.params.to);
+      assert.ok(Number.isFinite(from));
+      assert.ok(Number.isFinite(to));
+      const diffMs = to - from;
+      assert.ok(diffMs > 0);
+      const twentyFourHours = 24 * 60 * 60 * 1000;
+      assert.ok(Math.abs(diffMs - twentyFourHours) < 2000);
+      return [200, sampleResponse];
+    });
+
+    const result = await fetchNews({
+      query: 'Olahraga',
+      category: 'sports',
+      page: 1,
+      pageSize: 10,
+      sortBy: 'publishedAt',
+      timeRange: '24h',
+    });
+
+    assert.equal(result.timeRange, '24h');
+  });
+
+  it('converts axios errors to http errors', async () => {
+    mock.onGet(`${appConfig.gnews.baseUrl}/search`).reply(429, { message: 'Rate limit' });
+
+    await assert.rejects(
+      fetchNews({
+        query: 'politik',
+        category: 'business',
+        page: 1,
+        pageSize: 5,
+        sortBy: 'popularity',
+        timeRange: 'all',
+      }),
+      (error) => {
+        assert.equal(error.status, 429);
+        assert.equal(error.message, 'Rate limit');
+        return true;
+      },
+    );
+  });
+
+  it('throws helpful error when API key is missing', async () => {
+    appConfig.gnews.apiKey = '';
+
+    await assert.rejects(
+      fetchNews({
+        query: 'ekonomi',
+        category: 'business',
+        page: 1,
+        pageSize: 5,
+        sortBy: 'relevance',
+        timeRange: 'all',
+      }),
+      (error) => {
+        assert.equal(error.status, 500);
+        assert.match(
+          error.message,
+          /GNEWS_API_KEY/,
+        );
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a cache reset helper for the news service to support deterministic testing
- add a node:test suite that verifies fetchNews sanitization, caching, time range filters, and error handling
- add an npm script for backend tests and include axios-mock-adapter as a dev dependency

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68d8c84c58bc8327ac1cdd73d6ee1460